### PR TITLE
[FIX] ErrorCode 정의하지 않고 에러 처리할 수 있도록 수정

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/exception/BusinessException.java
@@ -1,13 +1,25 @@
 package com.animalfarm.backend.global.exception;
 
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 
 @Getter
 public class BusinessException extends RuntimeException {
-	private final ErrorCode errorCode;
+	private final String code;
+	private final HttpStatus httpStatus;
 
+	// 1. 미리 정의된 ErrorCode(ENUM) 사용
 	public BusinessException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
-		this.errorCode = errorCode;
+		this.code = errorCode.getCode();
+		this.httpStatus = errorCode.getHttpStatus();
+	}
+
+	// 2. 정의되지 않은 에러 사용
+	public BusinessException(HttpStatus httpStatus, String code, String message) {
+		super(message);
+		this.httpStatus = httpStatus;
+		this.code = code;
 	}
 }

--- a/backend/src/main/java/com/animalfarm/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/exception/GlobalExceptionHandler.java
@@ -24,11 +24,9 @@ public class GlobalExceptionHandler {
 	// 커스텀 에러 처리
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<ApiResponseDTO<Void>> handleBusinessException(BusinessException e) {
-		ErrorCode errorCode = e.getErrorCode();
-
 		return ResponseEntity
-			.status(errorCode.getHttpStatus())
-			.body(ApiResponseDTO.fail(errorCode.getCode(), e.getMessage()));
+			.status(e.getHttpStatus())
+			.body(ApiResponseDTO.fail(e.getCode(), e.getMessage()));
 	}
 
 	// 강황증권 API 에러 처리


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- ErrorCode 정의하지 않고 에러 처리할 수 있도록 수정

## 📝 변경 사항 (Key Changes)
- [ ] BusinessException의 errorCode 필드를 분해
- [ ] BusinessException에 생성자 추가
- [ ] GlobalExceptionHandler 수정

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
