### PR TITLE
[FIX] 토큰 거래소 컨트롤러에서 ApiResponseDTO 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/domain/token/TokenController.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/token/TokenController.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,8 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.animalfarm.backend.domain.token.dto.CandleDTO;
 import com.animalfarm.backend.domain.token.dto.OrderDTO;
 import com.animalfarm.backend.domain.token.dto.TokenDTO;
-import com.animalfarm.backend.domain.token.dto.TokenListDTO;
+import com.animalfarm.backend.domain.token.dto.TokenSummaryDTO;
 import com.animalfarm.backend.domain.token.dto.TokenPendingDTO;
+import com.animalfarm.backend.global.dto.ApiResponseDTO;
+import com.animalfarm.backend.global.exception.BusinessException;
+import com.animalfarm.backend.global.exception.ErrorCode;
 import com.animalfarm.backend.global.security.SecurityUtil;
 
 @RestController
@@ -25,73 +29,89 @@ public class TokenController {
 	TokenService tokenService;
 
 	@GetMapping("/api/token/{projectId}")
-	public TokenDTO selectDetail(@PathVariable("projectId") Long projectId) {
-		return tokenService.selectByProjectId(projectId);
+	public ResponseEntity<ApiResponseDTO<TokenDTO>> selectDetail(@PathVariable("projectId") Long projectId) {
+		TokenDTO data = tokenService.selectByProjectId(projectId);
+		return ResponseEntity.ok(ApiResponseDTO.success(data));
 	}
 
 	// 주문 가능 금액 조회
 	@GetMapping("/api/account/balance")
-	public BigDecimal selectCashBalance() {
+	public ResponseEntity<ApiResponseDTO<BigDecimal>> selectCashBalance() {
 		Long userId = SecurityUtil.getCurrentUserId();
-		if (userId != null) {
-			return tokenService.selectCashBalance(userId);
+		if (userId == null) {
+			throw new BusinessException(ErrorCode.NEED_LOGIN);
 		}
-		return null;
+
+		BigDecimal cashBalance = tokenService.selectCashBalance(userId);
+		return ResponseEntity.ok(ApiResponseDTO.success(cashBalance));
 	}
 
 	// 보유 토큰 수량 조회
 	@GetMapping("/api/account/balance/{tokenId}")
-	public BigDecimal selectTokenBalance(@PathVariable Long tokenId) {
+	public ResponseEntity<ApiResponseDTO<BigDecimal>> selectTokenBalance(@PathVariable Long tokenId) {
 		Long userId = SecurityUtil.getCurrentUserId();
-		if (userId != null) {
-			return tokenService.selectTokenBalance(tokenId, userId);
+		if (userId == null) {
+			throw new BusinessException(ErrorCode.NEED_LOGIN);
 		}
-		return null;
+
+		BigDecimal tokenBalance = tokenService.selectTokenBalance(tokenId, userId);
+		return ResponseEntity.ok(ApiResponseDTO.success(tokenBalance));
 	}
 
 	// 미체결 내역 조회
 	@GetMapping("/api/token/pending/{tokenId}")
-	public List<TokenPendingDTO> selectAllPending(@PathVariable Long tokenId) {
+	public ResponseEntity<ApiResponseDTO<List<TokenPendingDTO>>> selectAllPending(@PathVariable Long tokenId) {
 		Long userId = SecurityUtil.getCurrentUserId();
-		if (userId != null) {
-			return tokenService.selectAllPending(tokenId, userId);
+		if (userId == null) {
+			throw new BusinessException(ErrorCode.NEED_LOGIN);
 		}
-		return null;
+
+		List<TokenPendingDTO> pendingList = tokenService.selectAllPending(tokenId, userId);
+		return ResponseEntity.ok(ApiResponseDTO.success(pendingList));
 	}
 
 	// 주문 (매수, 매도)
 	@PostMapping("/api/token/order/{tokenId}")
-	public boolean createOrder(@PathVariable Long tokenId, @RequestBody OrderDTO orderDTO) {
+	public ResponseEntity<ApiResponseDTO<Void>> createOrder(@PathVariable Long tokenId, @RequestBody OrderDTO orderDTO) {
 		Long userId = SecurityUtil.getCurrentUserId();
-		if (userId != null) {
-			return tokenService.createOrder(userId, tokenId, orderDTO);
+		if (userId == null) {
+			throw new BusinessException(ErrorCode.NEED_LOGIN);
 		}
-		return false;
+
+		tokenService.createOrder(userId, tokenId, orderDTO);
+		return ResponseEntity.ok(
+			ApiResponseDTO.success(null, "주문이 완료되었습니다.")
+		);
 	}
 
 	// 주문 취소
 	@PostMapping("/api/token/order-cancel/{tokenId}/{orderId}")
-	public boolean cancelOrder(@PathVariable Long tokenId, @PathVariable Long orderId) {
-		return tokenService.cancelOrder(tokenId, orderId);
+	public ResponseEntity<ApiResponseDTO<Void>> cancelOrder(@PathVariable Long tokenId, @PathVariable Long orderId) {
+		tokenService.cancelOrder(tokenId, orderId);
+		return ResponseEntity.ok(
+			ApiResponseDTO.success(null, "주문이 취소되었습니다.")
+		);
 	}
 
 	// 캔들 조회
 	@GetMapping("/api/market/candles/{tokenId}")
-	public List<CandleDTO> selectCandles(
+	public ResponseEntity<ApiResponseDTO<List<CandleDTO>>> selectCandles(
 		@PathVariable Long tokenId,
 		@RequestParam(defaultValue = "1") int unit,
 		@RequestParam(required = false) Long start,
 		@RequestParam(required = false) Long end) {
 
-		return tokenService.selectCandles(tokenId, unit,
+		List<CandleDTO> candleList = tokenService.selectCandles(tokenId, unit,
 			start != null ? start : 0L,
 			end != null ? end : System.currentTimeMillis());
+		return ResponseEntity.ok(ApiResponseDTO.success(candleList));
 	}
 
 	// OHLCV 조회
 	@GetMapping("/api/token/ohlcv/{tokenId}")
-	public TokenListDTO selectTokenOhlcv(@PathVariable Long tokenId) {
-		return tokenService.selectTokenOhlcv(tokenId);
+	public ResponseEntity<ApiResponseDTO<TokenSummaryDTO>> selectTokenOhlcv(@PathVariable Long tokenId) {
+		TokenSummaryDTO tokenInfo = tokenService.selectTokenOhlcv(tokenId);
+		return ResponseEntity.ok(ApiResponseDTO.success(tokenInfo));
 	}
 
 }

--- a/backend/src/main/java/com/animalfarm/backend/domain/token/TokenService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/token/TokenService.java
@@ -18,7 +18,7 @@ import com.animalfarm.backend.domain.token.dto.OrderDTO;
 import com.animalfarm.backend.domain.token.dto.OrderPriceDTO;
 import com.animalfarm.backend.domain.token.dto.TokenDTO;
 import com.animalfarm.backend.domain.token.dto.TokenDetailDTO;
-import com.animalfarm.backend.domain.token.dto.TokenListDTO;
+import com.animalfarm.backend.domain.token.dto.TokenSummaryDTO;
 import com.animalfarm.backend.domain.token.dto.TokenPendingDTO;
 import com.animalfarm.backend.domain.token.dto.TradePriceDTO;
 import com.animalfarm.backend.global.dto.ExternalApiResponseDTO;
@@ -40,13 +40,13 @@ public class TokenService {
 	private String khUrl;
 
 	// 전체 토큰 시세 조회
-	public List<TokenListDTO> selectAll() {
+	public List<TokenSummaryDTO> selectAll() {
 		try {
-			List<TokenListDTO> list = externalApiClient.callApi(
+			List<TokenSummaryDTO> list = externalApiClient.callApi(
 				khUrl + "api/market",
 				HttpMethod.GET,
 				null,
-				new ParameterizedTypeReference<ExternalApiResponseDTO<List<TokenListDTO>>>() {}
+				new ParameterizedTypeReference<ExternalApiResponseDTO<List<TokenSummaryDTO>>>() {}
 			);
 
 			list.forEach(dto -> {
@@ -240,13 +240,13 @@ public class TokenService {
 		return true;
 	}
 
-	public TokenListDTO selectTokenOhlcv(Long tokenId) {
+	public TokenSummaryDTO selectTokenOhlcv(Long tokenId) {
 		try {
-			TokenListDTO token = externalApiClient.callApi(
+			TokenSummaryDTO token = externalApiClient.callApi(
 				khUrl + "api/market/ohlcv/" + tokenId,
 				HttpMethod.GET,
 				null,
-				new ParameterizedTypeReference<ExternalApiResponseDTO<TokenListDTO>>() {}
+				new ParameterizedTypeReference<ExternalApiResponseDTO<TokenSummaryDTO>>() {}
 			);
 
 			return token; // token이 null인 경우, null 반환

--- a/backend/src/main/java/com/animalfarm/backend/domain/token/dto/TokenSummaryDTO.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/token/dto/TokenSummaryDTO.java
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class TokenListDTO {
+public class TokenSummaryDTO {
 	private Long tokenId;
 	private String tokenName;
 	private String tickerSymbol;

--- a/backend/src/main/java/com/animalfarm/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
 
 	// 인증 관련 에러
 	INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH_001", "비밀번호가 일치하지 않습니다."),
+	NEED_LOGIN(HttpStatus.UNAUTHORIZED, "AUTH_002", "로그인이 필요한 서비스입니다."),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH_003", "로그인 정보가 만료되었습니다. 다시 로그인해주세요."),
 
 	// 시스템 에러
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "서버 내부 오류가 발생했습니다."),

--- a/backend/src/main/java/com/animalfarm/backend/global/security/SecurityUtil.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/security/SecurityUtil.java
@@ -3,6 +3,9 @@ package com.animalfarm.backend.global.security;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import com.animalfarm.backend.global.exception.BusinessException;
+import com.animalfarm.backend.global.exception.ErrorCode;
+
 /**
  * [보안 관련 공통 유틸리티]
  * 어느 서비스에서나 현재 로그인한 유저의 정보를 쉽게 가져올 수 있도록 합니다.
@@ -16,7 +19,7 @@ public class SecurityUtil {
 		Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
 		if (auth == null || auth.getPrincipal() == null || !(auth.getPrincipal() instanceof CustomUser)) {
-			throw new RuntimeException("로그인 정보가 만료되었습니다. 다시 로그인해주세요.");
+			throw new BusinessException(ErrorCode.TOKEN_EXPIRED);
 		}
 
 		CustomUser user = (CustomUser)auth.getPrincipal();


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 토큰 거래소 컨트롤러에서 ApiResponseDTO 반환하도록 수정
- OHLCV용 DTO 이름을 TokenListDTO > TokenSummaryDTO로 변경
- 로그인 정보 만료 시, 정의해놓은 TOKEN_EXPIRED 반환

## 📝 변경 사항 (Key Changes)
- [ ] TokenController
- [ ] TokenService
- [ ] TokenSummaryDTO
- [ ] ErrorCode
- [ ] SecurityUtil

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 조회 성공 | <img width="2880" height="1566" alt="image" src="https://github.com/user-attachments/assets/c7103670-8144-4a47-b711-a2491d41ea67" /> |
| 조회 실패 (로그인 토큰 만료) | <img width="2880" height="1524" alt="image" src="https://github.com/user-attachments/assets/ebac87f0-07e5-489e-90b8-086bb3969038" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
