### PR TITLE
[REFACTOR] externalApiClient 중복 코드 삭제

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/domain/project/FarmService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/project/FarmService.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 
 import com.animalfarm.backend.domain.project.dto.FarmDTO;
+import com.animalfarm.backend.global.dto.ExternalApiResponseDTO;
 import com.animalfarm.backend.global.http.ExternalApiClient;
 
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,7 @@ public class FarmService {
 	private String kakaoApiKey;
 
 	private final FarmRepository farmRepository;
-	private final ExternalApiClient apiUtil;
+	private final ExternalApiClient externalApiClient;
 
 	public List<FarmDTO> selectAllFarm() {
 		return farmRepository.selectAllFarm();
@@ -39,12 +40,11 @@ public class FarmService {
 		System.out.println(kakaoApiKey);
 
 		// 이제 제네릭 타입을 사용하여 안전하게 호출할 수 있습니다.
-		ParameterizedTypeReference<Map<String, Object>> typeRef =
-			new ParameterizedTypeReference<Map<String, Object>>() {
-			};
+		ParameterizedTypeReference<ExternalApiResponseDTO<Map<String, Object>>> typeRef =
+			new ParameterizedTypeReference<ExternalApiResponseDTO<Map<String, Object>>>() {};
 
 		// API 응답에서 x(경도), y(위도) 추출 로직 (간략화)
-		Map<String, Object> fullResponse = apiUtil.callExternalApi(url, HttpMethod.GET, null, typeRef, customHeaders);
+		Map<String, Object> fullResponse = externalApiClient.callApi(url, HttpMethod.GET, null, typeRef, customHeaders);
 		System.out.println(fullResponse);
 		if (fullResponse != null && fullResponse.containsKey("documents")) {
 			List<Map<String, Object>> documents = (List<Map<String, Object>>)fullResponse.get("documents");

--- a/backend/src/main/java/com/animalfarm/backend/domain/retry/ApiRetryProcessor.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/retry/ApiRetryProcessor.java
@@ -1,5 +1,8 @@
 package com.animalfarm.backend.domain.retry;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.scheduling.annotation.Async;
@@ -33,6 +36,7 @@ public class ApiRetryProcessor {
 
 		retry.setStatus("PROCESSING");
 		apiRetryQueueMapper.updateStatus(retry);
+		String idempotencyKey = retry.getIdempotencyKey();
 
 		try {
 			// DB의 문자열 타입을 다시 Enum 타입으로 복구
@@ -42,25 +46,28 @@ public class ApiRetryProcessor {
 			Object[] params = objectMapper.readValue(retry.getQuery(), Object[].class);
 			String fullUrl = KH_BASE_URL + type.getFullUri(params);
 
+			Map<String, String> headers = new HashMap<>();
+			headers.put("X-Idempotency-Key", idempotencyKey);
+
 			// 외부 API 호출 (멱등성 키 포함)
 			Object response = externalApiUtil.callApi(
 				fullUrl,
 				type.getMethod(),
 				retry.getPayload(),
-				new ParameterizedTypeReference<ExternalApiResponseDTO<Object>>() {
-				},
-				retry.getIdempotencyKey());
+				new ParameterizedTypeReference<ExternalApiResponseDTO<Object>>() {},
+				headers
+			);
 
 			// 성공 시 완료 처리
 			retry.setStatus("COMPLETED");
 			apiRetryQueueMapper.updateStatus(retry);
-			log.info("재시도 성공했습니다. Key: {}", retry.getIdempotencyKey());
+			log.info("재시도 성공했습니다. Key: {}", idempotencyKey);
 
 			apiRetryService.afterRetrySuccess(retry, response);
 
 		} catch (Exception e) {
 			// 실패
-			log.warn("재시도 실패했습니다. Key: {}, 사유: {}", retry.getIdempotencyKey(), e.getMessage());
+			log.warn("재시도 실패했습니다. Key: {}, 사유: {}", idempotencyKey, e.getMessage());
 			service.handleFailure(retry);
 		}
 	}

--- a/backend/src/main/java/com/animalfarm/backend/domain/subscription/SubscriptionService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/subscription/SubscriptionService.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -92,15 +93,21 @@ public class SubscriptionService {
 
 		// 멱등성 키 생성
 		String idempotencyKey = "SUB-CANCEL-" + subscriptionHistDTO.getShId();
+		Map<String, String> headers = new HashMap<>();
+		headers.put("X-Idempotency-Key", idempotencyKey);
 
 		// url 생성
 		String url = KH_BASE_URL + "api/project/cancel/" + subscriptionHistDTO.getExternalRefId();
 		RefundDTO refundDTO = null;
 		try {
 			// 취소 및 환불 요청
-			refundDTO = externalApiUtil.callApi(url, HttpMethod.POST, subscriptionHistDTO,
-				new ParameterizedTypeReference<ExternalApiResponseDTO<RefundDTO>>() {
-				}, idempotencyKey);
+			refundDTO = externalApiUtil.callApi(
+				url,
+				HttpMethod.POST,
+				subscriptionHistDTO,
+				new ParameterizedTypeReference<ExternalApiResponseDTO<RefundDTO>>() {},
+				headers
+			);
 
 			if (refundDTO == null) {
 				throw new Exception("환불 처리에 실패했습니다.");
@@ -334,15 +341,21 @@ public class SubscriptionService {
 
 			// 멱등성 키 생성
 			String idempotencyKey = "SUB-REJECTED-" + subscriptionHistDTO.getShId();
+			Map<String, String> headers = new HashMap<>();
+			headers.put("X-Idempotency-Key", idempotencyKey);
 
 			// url 생성
 			String url = KH_BASE_URL + "api/project/cancel/" + subscriptionHistDTO.getExternalRefId();
 			RefundDTO refundDTO = null;
 			try {
 				// 취소 및 환불 요청
-				refundDTO = externalApiUtil.callApi(url, HttpMethod.POST, subscriptionHistDTO,
-					new ParameterizedTypeReference<ExternalApiResponseDTO<RefundDTO>>() {
-					}, idempotencyKey);
+				refundDTO = externalApiUtil.callApi(
+					url,
+					HttpMethod.POST,
+					subscriptionHistDTO,
+					new ParameterizedTypeReference<ExternalApiResponseDTO<RefundDTO>>() {},
+					headers
+				);
 
 				if (refundDTO == null) {
 					throw new Exception("환불 처리에 실패했습니다.");

--- a/backend/src/main/java/com/animalfarm/backend/domain/token/TokenBurnTasklet.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/token/TokenBurnTasklet.java
@@ -1,6 +1,7 @@
 package com.animalfarm.backend.domain.token;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -46,15 +47,17 @@ public class TokenBurnTasklet implements Tasklet {
 		// 거래 중지 & 토큰 소각 API 요청
 		final String burnUrl = KH_BASE_URL + "/api/project/close/" + tokenId;
 		String idempotencyKey = "BURN-" + tokenId;
+		Map<String, String> headers = new HashMap<>();
+		headers.put("X-Idempotency-Key", idempotencyKey);
 
 		try {
 			// 증권사에서 uclId(walletId), external_ref_id(transactionId), amount 보내줌
 			List<RefundDTO> refundOriginList = externalApiUtil.callApi(burnUrl,
 				HttpMethod.POST,
 				null,
-				new ParameterizedTypeReference<ExternalApiResponseDTO<List<RefundDTO>>>() {
-				},
-				idempotencyKey);
+				new ParameterizedTypeReference<ExternalApiResponseDTO<List<RefundDTO>>>() {},
+				headers
+			);
 
 			// JobExecutionContext에 저장 (다음 Step으로 넘기기 위함)
 			ExecutionContext jobContext = chunkContext.getStepContext().getStepExecution()

--- a/backend/src/main/java/com/animalfarm/backend/global/http/ExternalApiClient.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/http/ExternalApiClient.java
@@ -1,5 +1,6 @@
 package com.animalfarm.backend.global.http;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.core.ParameterizedTypeReference;
@@ -23,53 +24,35 @@ public class ExternalApiClient {
 
 	private final WebClient webClient;
 
-	// 강황증권 API 호출 메서드 - 멱등성 키 X
+	/* 강황증권 API 호출 메서드
+	 **
+	 */
+
+	// 헤더 X
 	public <T> T callApi(String url, HttpMethod method, Object body,
 		ParameterizedTypeReference<ExternalApiResponseDTO<T>> responseType) {
 		return callApi(url, method, body, responseType, null);
 	}
 
-	// 강황증권 API 호출 메서드 - 멱등성 키 O
+	/*
+	// 헤더 O (멱등성 키)
 	public <T> T callApi(String url, HttpMethod method, Object body,
 		ParameterizedTypeReference<ExternalApiResponseDTO<T>> responseType, String idempotencyKey) {
 
-		// 1. 요청 준비 (Request Spec 설정)
-		WebClient.RequestBodySpec requestSpec = webClient.method(method)
-			.uri(url)
-			.headers(headers -> {
-				headers.setContentType(MediaType.APPLICATION_JSON);
-				if (idempotencyKey != null && !idempotencyKey.isEmpty()) {
-					headers.set("X-Idempotency-Key", idempotencyKey);
-				}
-			});
-
-		// 2. 바디 설정 (null이면 세팅 안 함)
-		if (body != null) {
-			requestSpec.bodyValue(body);
+		// 멱등성 키가 있다면 헤더에 추가
+		Map<String, String> headers = new HashMap<>();
+		if (idempotencyKey != null && !idempotencyKey.isEmpty()) {
+			headers.put("X-Idempotency-Key", idempotencyKey);
 		}
 
-		// 3. 요청 전송 및 응답 처리
-		ExternalApiResponseDTO<T> response = requestSpec
-			.retrieve()
-			.onStatus(HttpStatusCode::isError, clientResponse ->
-				clientResponse.bodyToMono(String.class)
-					.flatMap(errorBody -> Mono.error(new ExternalApiException(
-						clientResponse.statusCode().value(),
-						errorBody
-					)))
-			)
-			.bodyToMono(responseType) // 응답값을 responseType 형태로 변환
-			.block(); // 동기
-		if (response == null) {
-			throw new RuntimeException("API 응답이 비어있습니다.");
-		}
-
-		log.info("[API Success] URL: {}, Msg: {}", url, response.getMessage());
-		return response.getPayload();
+		// 공통 메서드 호출
+		return callApi(url, method, body, responseType, headers);
 	}
+	 */
 
-	public <T> T callExternalApi(String url, HttpMethod method, Object body,
-		ParameterizedTypeReference<T> responseType, Map<String, String> customHeaders) {
+	// 헤더 O (멱등성 키 포함)
+	public <T> T callApi(String url, HttpMethod method, Object body,
+		ParameterizedTypeReference<ExternalApiResponseDTO<T>> responseType, Map<String, String> customHeaders) {
 
 		// 1. 요청 준비 (WebClient 방식)
 		WebClient.RequestBodySpec requestSpec = webClient.method(method)
@@ -89,23 +72,29 @@ public class ExternalApiClient {
 
 		// 3. 실행 및 예외 처리
 		try {
-			return requestSpec
+			// 3. 요청 전송 및 응답 처리
+			ExternalApiResponseDTO<T> response = requestSpec
 				.retrieve()
 				// API 응답 에러 처리 (4xx, 5xx)
 				.onStatus(HttpStatusCode::isError, clientResponse ->
 					clientResponse.bodyToMono(String.class)
 						.flatMap(errorBody -> {
-							log.error("[External API Fail] Status: {}, Body: {}", clientResponse.statusCode(),
-								errorBody);
+							log.error("[External API Fail] Status: {}, Body: {}", clientResponse.statusCode(), errorBody);
 							return Mono.error(new ExternalApiException(
 								clientResponse.statusCode().value(),
 								errorBody
 							));
 						})
 				)
-				// 이 메서드는 DTO로 감싸지 않고 바로 T 타입을 반환함
-				.bodyToMono(responseType)
+				.bodyToMono(responseType) // 응답값을 responseType 형태로 변환
 				.block(); // 동기식으로 결과 대기
+
+			if (response == null) {
+				throw new RuntimeException("API 응답이 비어있습니다.");
+			}
+
+			log.info("[External API Success] URL: {}, Msg: {}", url, response.getMessage());
+			return response.getPayload();
 
 		} catch (ExternalApiException e) {
 			// 비즈니스 에러는 그대로 던짐


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- externalApiClient 중복 코드 삭제

## 📝 변경 사항 (Key Changes)
- [ ] 멱등성 키를 String으로 전달한 후, 내부에서 헤더 생성 및 추가하는 callApi 함수 제거
- [ ] 멱등성 키 존재하는 callApi 호출 시, 미리 헤더에 담아서 전달하도록 수정

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 기능명 | 사진첨부 |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
