### PR TITLE
[FIX] 호가창 막대그래프 변환 & 가격 클릭시 주문 가격 자동 입력

### DIFF
--- a/frontend/src/pages/Token/TokenDetail.tsx
+++ b/frontend/src/pages/Token/TokenDetail.tsx
@@ -20,6 +20,11 @@ export default function TokenDetail() {
   const [sellList, setSellList] = useState<OrderInfo[]>([]);
   const [tradeList, setTradeList] = useState<TradeInfo[]>([]);
   const navigate = useNavigate();
+  const [selectedPrice, setSelectedPrice] = useState<number | null>(null);
+
+  useEffect(() => {
+    setSelectedPrice(null);
+  }, [id]);
 
   // 1. 토큰 목록 조회 (마운트 시 1회)
   useEffect(() => {
@@ -42,11 +47,6 @@ export default function TokenDetail() {
     setBuyList(buyRes);
     setSellList(sellRes);
     setTradeList(tradeRes);
-
-    console.log('Token Ohlcv:', ohlcvRes);
-    console.log('Buy List:', buyRes);
-    console.log('Sell List:', sellRes);
-    console.log('Trade List:', tradeRes);
   };
 
   useEffect(() => {
@@ -81,7 +81,7 @@ export default function TokenDetail() {
           <div className="flex flex-col gap-6">
             <TokenTradeCard
               tokenId={Number(id)}
-              marketPrice={tokenOhlcv?.marketPrice || 0}
+              marketPrice={selectedPrice || tokenOhlcv?.marketPrice || 0}
               tickerSymbol={tokenOhlcv?.tickerSymbol || '-'}
             />
             <TokenPriceCard
@@ -89,6 +89,7 @@ export default function TokenDetail() {
               buyList={buyList}
               sellList={sellList}
               tradeList={tradeList}
+              onPriceClick={(price) => setSelectedPrice(price)}
             />
           </div>
         </div>

--- a/frontend/src/pages/Token/components/tokenDetail/TokenListCard.tsx
+++ b/frontend/src/pages/Token/components/tokenDetail/TokenListCard.tsx
@@ -16,7 +16,7 @@ export default function TokenListCard({
     <div className="bg-white border border-gray-100 rounded-[var(--radius-m)] shadow-std overflow-hidden">
       <div className="overflow-y-auto max-h-[600px] scrollbar-hide">
         <table className="w-full border-collapse text-left font-body-03">
-          <thead className="sticky top-0 bg-white z-10">
+          <thead className="bg-gray-50">
             <tr>
               <th className="pl-6 font-body-02 text-gray-400 border-bottom border-gray-200">
                 종목

--- a/frontend/src/pages/Token/components/tokenDetail/TokenPriceCard.tsx
+++ b/frontend/src/pages/Token/components/tokenDetail/TokenPriceCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import ToggleGroup from '@/components/common/ToggleGroup';
 import type { OrderInfo, TokenOhlcv, TradeInfo } from '@/types/tokenType';
 
@@ -7,6 +7,7 @@ interface TokenPriceCardProps {
   buyList: OrderInfo[];
   sellList: OrderInfo[];
   tradeList: TradeInfo[];
+  onPriceClick: (price: number) => void;
 }
 
 export default function TokenPriceCard({
@@ -14,6 +15,7 @@ export default function TokenPriceCard({
   buyList,
   sellList,
   tradeList,
+  onPriceClick
 }: TokenPriceCardProps) {
   const [activeTab, setActiveTab] = useState('order');
   const tabs = [
@@ -40,51 +42,56 @@ export default function TokenPriceCard({
     const tickSize = getTickSize(marketPrice);
     const basePrice = Math.round(marketPrice / tickSize) * tickSize; // 현재가를 호가 단위에 맞춰 보정
 
-    const sellMap = new Map<string, number>();
-    sellList.forEach((s) =>
+    const sellMap = new Map<number, number>(); // <가격, 수량>
+    sellList.forEach((s) => {
+      const priceNum = Number(s.price);
       sellMap.set(
-        Number(s.price).toFixed(2),
-        (sellMap.get(Number(s.price).toFixed(2)) || 0) + Number(s.volume),
-      ),
-    );
+        priceNum,
+        (sellMap.get(priceNum) || 0) + Number(s.totalVolume)
+      );
+    });
 
-    const buyMap = new Map<string, number>();
-    buyList.forEach((b) =>
+    const buyMap = new Map<number, number>(); // <가격, 수량>
+    buyList.forEach((b) => {
+      const priceNum = Number(b.price);
       buyMap.set(
-        Number(b.price).toFixed(2),
-        (buyMap.get(Number(b.price).toFixed(2)) || 0) + Number(b.volume),
-      ),
-    );
+        priceNum,
+        (buyMap.get(priceNum) || 0) + Number(b.totalVolume)
+      );
+    });
 
     const rows = [];
 
-    // 매도 10개 (위로)
+    // 1. 매도 10개 (위로)
     for (let i = 10; i >= 1; i--) {
       const p = basePrice + i * tickSize;
       rows.push({
         price: p,
-        volume: sellMap.get(p.toFixed(2)) || 0,
-        type: 'SELL' as const,
+        volume: sellMap.get(p) || 0,
+        side: 'SELL',
+        isCurrent: false
       });
     }
 
-    // 현재가
+    // 2. 현재가
+    const sVol = sellMap.get(basePrice) || 0;
+    const bVol = buyMap.get(basePrice) || 0;
+
     rows.push({
       price: basePrice,
-      volume:
-        sellMap.get(basePrice.toFixed(2)) ||
-        buyMap.get(basePrice.toFixed(2)) ||
-        0,
-      type: 'CURRENT' as const,
+      volume: sVol > 0 ? sVol : bVol,
+      side: sVol > 0 ? 'SELL' : 'BUY',
+      isCurrent: true
     });
 
-    // 매수 10개 (아래로)
+    // 3. 매수 10개 (아래로)
     for (let i = 1; i <= 10; i++) {
       const p = basePrice - i * tickSize;
       rows.push({
         price: p,
-        volume: buyMap.get(p.toFixed(2)) || 0,
-        type: 'BUY' as const,
+        volume: buyMap.get(p) || 0,
+        side: 'BUY',
+        isCurrent: false
       });
     }
 
@@ -120,30 +127,24 @@ export default function TokenPriceCard({
             </thead>
             <tbody>
               {ladder.map((row, idx) => {
-                const isCurrent = row.type === 'CURRENT';
-                const priceColor =
-                  row.type === 'SELL'
-                    ? 'text-info'
-                    : row.type === 'BUY'
-                      ? 'text-error'
-                      : 'text-gray-900';
+                const priceColor = row.side === 'SELL' ? 'text-info' : 'text-error';
 
                 return (
                   <tr
                     key={idx}
                     className={
-                      'h-10 hover:bg-gray-50 transition-colors cursor-pointer'
+                      'h-10'
                     }
                   >
                     {/* 매도 물량 바 */}
                     <td className="relative py-3 text-right text-[12px] font-medium text-gray-500">
-                      {row.type === 'SELL' && row.volume > 0 && (
+                      {row.side === 'SELL' && row.volume > 0 && (
                         <>
                           <div
-                            className="absolute right-0 top-1 bottom-1 bg-info/10 rounded-l-sm transition-all duration-500"
-                            style={{ width: `${row.ratio}%` }}
+                            className="absolute right-0 top-1 bottom-1 bg-info-light rounded-l-[var(--radius-s)] transition-all duration-500"
+                            style={{ width: `${row.ratio}%`, zIndex: 1 }}
                           />
-                          <span className="relative z-10">
+                          <span className="relative z-10 pr-1">
                             {Number(row.volume).toFixed(4)}
                           </span>
                         </>
@@ -152,20 +153,21 @@ export default function TokenPriceCard({
 
                     {/* 가격 */}
                     <td
-                      className={`py-3 text-center font-body-03 border-x border-gray-50/10 ${priceColor} ${isCurrent ? 'border border-[${priceColor}]' : ''}`}
+                      onClick={() => onPriceClick(row.price)}
+                      className={`py-3 text-center font-body-03 hover:bg-gray-50 transition-colors cursor-pointer ${priceColor} ${row.isCurrent ? 'border-2 border-[${priceColor}]' : ''}`}
                     >
                       {row.price?.toLocaleString()}
                     </td>
 
                     {/* 매수 물량 바 */}
                     <td className="relative py-3 text-left text-[12px] font-medium text-gray-500">
-                      {row.type === 'BUY' && row.volume > 0 && (
+                      {row.side === 'BUY' && row.volume > 0 && (
                         <>
                           <div
-                            className="absolute left-0 top-1 bottom-1 bg-error/10 rounded-r-sm transition-all duration-500"
+                            className="absolute left-0 top-1 bottom-1 bg-error-light rounded-r-[var(--radius-s)] transition-all duration-500"
                             style={{ width: `${row.ratio}%` }}
                           />
-                          <span className="relative z-10">
+                          <span className="relative z-10 pl-1">
                             {Number(row.volume).toFixed(4)}
                           </span>
                         </>
@@ -195,7 +197,7 @@ export default function TokenPriceCard({
                 // );
 
                 return (
-                  <tr key={idx} className="h-10 hover:bg-gray-50">
+                  <tr key={idx} className="h-10">
                     <td className="py-3 pl-4 font-body-03">
                       {/* 
                       <span className="text-gray-400 mr-2 text-[10px]">

--- a/frontend/src/pages/Token/components/tokenDetail/TokenTradeCard.tsx
+++ b/frontend/src/pages/Token/components/tokenDetail/TokenTradeCard.tsx
@@ -27,9 +27,7 @@ export default function TokenTradeCard({
 
   const [activeTab, setActiveTab] = useState('buy'); // buy | sell | pending
   const [orderType, setOrderType] = useState('LIMIT'); // LIMIT | MARKET
-  const [price, setPrice] = useState(
-    marketPrice ? marketPrice.toLocaleString() : '',
-  );
+  const [price, setPrice] = useState('');
   const [volume, setVolume] = useState('');
   const [amount, setAmount] = useState('');
   const [pendingList, setPendingList] = useState<TokenPending[]>([]);
@@ -38,6 +36,12 @@ export default function TokenTradeCard({
   const getNumPrice = () => Number(price.replace(/,/g, '')) || 0;
   const getNumVolume = () => Number(volume) || 0;
   const getNumAmount = () => Number(amount.replace(/,/g, '')) || 0;
+
+  useEffect(() => {
+    if (marketPrice && marketPrice > 0) {
+      setPrice(marketPrice.toLocaleString());
+    }
+  }, [marketPrice]);
 
   // 1. 숫자 포맷팅 함수 (천단위 콤마 및 커서 제어)
   const formatNumber = (val: string) => {

--- a/frontend/src/types/tokenType.ts
+++ b/frontend/src/types/tokenType.ts
@@ -72,7 +72,7 @@ export interface Order {
 // 호가 정보
 export interface OrderInfo {
   price: string;
-  volume: string;
+  totalVolume: string;
   side: 'BUY' | 'SELL';
 }
 


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 호가창 막대그래프 변환
- 가격 클릭시 주문 가격 자동 입력
- 웹소켓 X

## 📝 변경 사항 (Key Changes)
- [ ] TokenTradeCard 막대그래프
- [ ] TokenDetail에서 주문 가격 상태 관리 -> TokenTradeCard, TokenPriceCard에 전달
- [ ] 호가 정보 수량 변수명 totalVolume으로 통일 (=백엔드)

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 호가창 | <img width="407" height="709" alt="image" src="https://github.com/user-attachments/assets/1c4cd5d8-f73b-42a0-bec8-955e55839530" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #73 

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
