### PR TITLE
[FEAT] 회원가입 컴포넌트화 및 비밀번호 로직 수정

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/domain/user/service/AuthService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/user/service/AuthService.java
@@ -2,6 +2,7 @@ package com.animalfarm.backend.domain.user.service;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -31,12 +32,42 @@ public class AuthService {
 	@Autowired
 	private PasswordEncoder passwordEncoder;
 
+	private static final Pattern LETTER_PATTERN = Pattern.compile("[A-Za-z]");
+	private static final Pattern NUMBER_PATTERN = Pattern.compile("[0-9]");
+	private static final Pattern SPECIAL_PATTERN = Pattern.compile("[^A-Za-z0-9]");
+
 	private boolean isBlank(String s) {
 		return s == null || s.isBlank();
 	}
 
 	private String emailVerifiedKey(String email) {
 		return "EMAIL_VERIFIED:" + email;
+	}
+
+	private void validatePasswordRule(String password) {
+		boolean hasLetter = LETTER_PATTERN.matcher(password).find();
+		boolean hasNumber = NUMBER_PATTERN.matcher(password).find();
+		boolean hasSpecial = SPECIAL_PATTERN.matcher(password).find();
+
+		int combinationCount = 0;
+		if (hasLetter)
+			combinationCount++;
+		if (hasNumber)
+			combinationCount++;
+		if (hasSpecial)
+			combinationCount++;
+
+		if (combinationCount < 2) {
+			throw new IllegalArgumentException("비밀번호는 영문, 숫자, 특수문자 중 2종류 이상을 조합해야 합니다.");
+		}
+
+		if (combinationCount == 2 && password.length() < 10) {
+			throw new IllegalArgumentException("비밀번호는 영문, 숫자, 특수문자 중 2종류 조합 시 10자 이상이어야 합니다.");
+		}
+
+		if (combinationCount >= 3 && password.length() < 8) {
+			throw new IllegalArgumentException("비밀번호는 영문, 숫자, 특수문자 중 3종류 이상 조합 시 8자 이상이어야 합니다.");
+		}
 	}
 
 	// 로그인
@@ -113,6 +144,9 @@ public class AuthService {
 		if (isBlank(req.getUserName())) {
 			throw new IllegalArgumentException("이름이 필요합니다.");
 		}
+		if (isBlank(req.getPhoneNumber())) {
+			throw new IllegalArgumentException("휴대폰 번호가 필요합니다.");
+		}
 
 		if (userRepository.findByEmail(req.getEmail()) != null) {
 			throw new IllegalArgumentException("이미 가입된 이메일입니다.");
@@ -122,6 +156,8 @@ public class AuthService {
 		if (verified == null) {
 			throw new IllegalStateException("이메일 인증이 완료되지 않았습니다.");
 		}
+
+		validatePasswordRule(req.getPassword());
 
 		UserDTO user = new UserDTO();
 		user.setEmail(req.getEmail());

--- a/frontend/src/components/common/AuthCard.tsx
+++ b/frontend/src/components/common/AuthCard.tsx
@@ -13,7 +13,7 @@ export default function AuthCard({
 }: AuthCardProps) {
   return (
     <div className="w-full max-w-lg">
-      <div className="bg-white p-10 rounded-2xl border border-gray-100 shadow-2xs">
+      <div className="bg-white p-10 rounded-2xl border border-gray-100 shadow-std">
         
         <h2 className="font-header-02 text-center mb-3">
           {title}

--- a/frontend/src/components/common/AuthCard.tsx
+++ b/frontend/src/components/common/AuthCard.tsx
@@ -12,15 +12,15 @@ export default function AuthCard({
   children,
 }: AuthCardProps) {
   return (
-    <div className="w-full max-w-[520px]">
-      <div className="bg-white p-10 rounded-[var(--radius-m)] border border-gray-100 shadow-[0_4px_24px_rgba(0,0,0,0.06)]">
+    <div className="w-full max-w-lg">
+      <div className="bg-white p-10 rounded-2xl border border-gray-100 shadow-2xs">
         
-        <h2 className="text-center text-[24px] leading-[1.4] font-bold text-gray-900 mb-3">
+        <h2 className="font-header-02 text-center mb-3">
           {title}
         </h2>
 
         {description && (
-          <p className="text-center text-[14px] leading-[1.5] text-gray-500 mb-8">
+          <p className="font-body-01 text-center mb-10">
             {description}
           </p>
         )}

--- a/frontend/src/pages/Auth/Signup.tsx
+++ b/frontend/src/pages/Auth/Signup.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import apiClient from "@/api/apiClient";
-import Button from "@/components/common/Button";
-import Input from "@/components/common/Input";
-import {
-  CheckCircle,
-  WarningCircle,
-  PersonalUser,
-  EnterpriseUser,
-} from "@/components/icon/Icons";
-
-type SignUpType = "PERSONAL" | "ENTERPRISE" | null;
+import { CheckCircle, WarningCircle } from "@/components/icon/Icons";
+import SignupAgreeStep from "./components/SignupAgreeStep";
+import SignupProgress from "./components/SignupProgress";
+import SignupSelect from "./components/SignupSelect";
+import SignupEnterpriseStep from "./components/SignupEnterpriseStep";
+import SignupPersonalStep, {
+  type FormState,
+  type SignUpType,
+  type StatusState,
+} from "./components/SignupPersonalStep";
+import { validatePassword } from "./hook/passwordValidation";
 
 type EnterpriseVerifyResponse = {
   verified: boolean;
@@ -26,104 +27,148 @@ type SignUpPayload = {
   brn?: string;
 };
 
+type SignupHistoryState = {
+  signupForm?: FormState;
+};
+
 const EMAIL_EXPIRE_SEC = 300;
 
-export default function Signup() {
-  const navigate = useNavigate();
-
-  const [signUpType, setSignUpType] = useState<SignUpType>(null);
-  const [step, setStep] = useState(1);
-
-  const [agreements, setAgreements] = useState({
+const initialFormState: FormState = {
+  signUpType: null,
+  step: 1,
+  agreements: {
     service: false,
     privacy: false,
     push: false,
-  });
+  },
+  bNo: "",
+  bNoVerified: false,
+  cautionAgreed: false,
+  phone: "",
+  phoneVerified: false,
+  email: "",
+  emailCode: "",
+  emailVerified: false,
+  emailExpireAt: null,
+  userName: "",
+};
 
-  const [bNo, setBNo] = useState("");
-  const [bNoVerified, setBNoVerified] = useState(false);
-  const [bNoStatus, setBNoStatus] = useState<{ msg: string; ok: boolean | null }>({
-    msg: "",
-    ok: null,
-  });
-
-  const [cautionAgreed, setCautionAgreed] = useState(false);
-  const [cautionStatus, setCautionStatus] = useState<{ msg: string; ok: boolean | null }>({
-    msg: "",
-    ok: null,
-  });
-
-  const [phone, setPhone] = useState("");
-  const [phoneVerified, setPhoneVerified] = useState(false);
-  const [phoneStatus, setPhoneStatus] = useState<{ msg: string; ok: boolean | null }>({
-    msg: "",
-    ok: null,
-  });
-
-  const [email, setEmail] = useState("");
-  const [emailCode, setEmailCode] = useState("");
-  const [emailVerified, setEmailVerified] = useState(false);
-  const [emailSendStatus, setEmailSendStatus] = useState<{ msg: string; ok: boolean | null }>({
-    msg: "",
-    ok: null,
-  });
-  const [emailVerifyStatus, setEmailVerifyStatus] = useState<{ msg: string; ok: boolean | null }>(
-    {
-      msg: "",
-      ok: null,
-    }
-  );
-  const [emailRemainSec, setEmailRemainSec] = useState(0);
+export default function Signup() {
+  const navigate = useNavigate();
+  const location = useLocation();
   const emailTimerRef = useRef<number | null>(null);
+  const restoringRef = useRef(true);
 
-  const [userName, setUserName] = useState("");
+  const [form, setForm] = useState<FormState>(initialFormState);
+
+  const [bNoStatus, setBNoStatus] = useState<StatusState>({ msg: "", ok: null });
+  const [cautionStatus, setCautionStatus] = useState<StatusState>({ msg: "", ok: null });
+  const [phoneStatus, setPhoneStatus] = useState<StatusState>({ msg: "", ok: null });
+  const [emailSendStatus, setEmailSendStatus] = useState<StatusState>({ msg: "", ok: null });
+  const [emailVerifyStatus, setEmailVerifyStatus] = useState<StatusState>({ msg: "", ok: null });
+  const [signupStatus, setSignupStatus] = useState<StatusState>({ msg: "", ok: null });
+
+  const [emailRemainSec, setEmailRemainSec] = useState(0);
   const [password, setPassword] = useState("");
   const [password2, setPassword2] = useState("");
-  const [signupStatus, setSignupStatus] = useState<{ msg: string; ok: boolean | null }>({
-    msg: "",
-    ok: null,
-  });
 
   const [loading, setLoading] = useState({
     enterpriseVerify: false,
-    emailSend: false,
     emailConfirm: false,
     signup: false,
   });
 
-  const totalSteps = signUpType === "PERSONAL" ? 5 : 7;
+  const totalSteps = form.signUpType === "PERSONAL" ? 5 : 7;
 
   const currentDotIndex = useMemo(() => {
-    if (signUpType === "PERSONAL") {
+    if (form.signUpType === "PERSONAL") {
       const map: Record<number, number> = { 1: 1, 4: 2, 5: 3, 6: 4, 7: 5 };
-      return map[step] ?? 1;
+      return map[form.step] ?? 1;
     }
-    return step;
-  }, [signUpType, step]);
+    return form.step;
+  }, [form.signUpType, form.step]);
+
+  const allChecked =
+    form.agreements.service && form.agreements.privacy && form.agreements.push;
+  const requiredChecked = form.agreements.service && form.agreements.privacy;
+
+  const passwordMatched =
+    password.length > 0 || password2.length > 0 ? password === password2 : null;
+
+  const passwordValidation = validatePassword(password);
 
   useEffect(() => {
-    if (emailRemainSec <= 0) {
+    const state = window.history.state as SignupHistoryState | null;
+    const savedForm = state?.signupForm;
+
+    if (savedForm) {
+      const restoredExpireAt = savedForm.emailExpireAt;
+      const restoredRemain = restoredExpireAt
+        ? Math.max(0, Math.floor((restoredExpireAt - Date.now()) / 1000))
+        : 0;
+
+      setForm({
+        ...savedForm,
+        emailExpireAt: restoredRemain > 0 ? restoredExpireAt : null,
+        emailVerified: savedForm.emailVerified,
+      });
+      setEmailRemainSec(restoredRemain);
+
+      if (restoredExpireAt && restoredRemain <= 0 && !savedForm.emailVerified) {
+        setEmailSendStatus({ msg: "인증번호가 만료되었습니다. 재전송해주세요.", ok: false });
+      }
+    }
+
+    restoringRef.current = false;
+  }, []);
+
+  useEffect(() => {
+    if (restoringRef.current) return;
+
+    const prevState = (window.history.state ?? {}) as SignupHistoryState;
+    window.history.replaceState(
+      {
+        ...prevState,
+        signupForm: form,
+      },
+      ""
+    );
+  }, [form]);
+
+  useEffect(() => {
+    const expireAt = form.emailExpireAt;
+
+    if (!expireAt) {
       if (emailTimerRef.current) {
         window.clearInterval(emailTimerRef.current);
         emailTimerRef.current = null;
       }
+      setEmailRemainSec(0);
       return;
     }
 
-    emailTimerRef.current = window.setInterval(() => {
-      setEmailRemainSec((prev) => {
-        if (prev <= 1) {
-          if (emailTimerRef.current) {
-            window.clearInterval(emailTimerRef.current);
-            emailTimerRef.current = null;
-          }
-          setEmailVerified(false);
-          setEmailSendStatus({ msg: "인증번호가 만료되었습니다. 재전송해주세요.", ok: false });
-          return 0;
+    const updateRemain = () => {
+      const remain = Math.max(0, Math.floor((expireAt - Date.now()) / 1000));
+      setEmailRemainSec(remain);
+
+      if (remain <= 0) {
+        if (emailTimerRef.current) {
+          window.clearInterval(emailTimerRef.current);
+          emailTimerRef.current = null;
         }
-        return prev - 1;
-      });
-    }, 1000);
+
+        setForm((prev) => ({
+          ...prev,
+          emailExpireAt: null,
+          emailVerified: false,
+        }));
+
+        setEmailSendStatus({ msg: "인증번호가 만료되었습니다. 재전송해주세요.", ok: false });
+      }
+    };
+
+    updateRemain();
+    emailTimerRef.current = window.setInterval(updateRemain, 1000);
 
     return () => {
       if (emailTimerRef.current) {
@@ -131,7 +176,30 @@ export default function Signup() {
         emailTimerRef.current = null;
       }
     };
-  }, [emailRemainSec]);
+  }, [form.emailExpireAt]);
+
+  useEffect(() => {
+    return () => {
+      const currentPath = location.pathname;
+      const nextState = window.history.state as SignupHistoryState | null;
+
+      if (currentPath !== "/auth/signup") {
+        return;
+      }
+
+      window.history.replaceState(
+        {
+          ...(nextState ?? {}),
+          signupForm: undefined,
+        },
+        ""
+      );
+    };
+  }, [location.pathname]);
+
+  const updateForm = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
 
   const formatMMSS = (sec: number) => {
     const m = String(Math.floor(sec / 60)).padStart(2, "0");
@@ -139,68 +207,67 @@ export default function Signup() {
     return `${m}:${s}`;
   };
 
-  const resetForm = () => {
-    setStep(1);
-    setAgreements({ service: false, privacy: false, push: false });
+  const resetForm = (type: SignUpType) => {
+    if (emailTimerRef.current) {
+      window.clearInterval(emailTimerRef.current);
+      emailTimerRef.current = null;
+    }
 
-    setBNo("");
-    setBNoVerified(false);
+    setForm({
+      ...initialFormState,
+      signUpType: type,
+    });
+
     setBNoStatus({ msg: "", ok: null });
-
-    setCautionAgreed(false);
     setCautionStatus({ msg: "", ok: null });
-
-    setPhone("");
-    setPhoneVerified(false);
     setPhoneStatus({ msg: "", ok: null });
-
-    setEmail("");
-    setEmailCode("");
-    setEmailVerified(false);
     setEmailSendStatus({ msg: "", ok: null });
     setEmailVerifyStatus({ msg: "", ok: null });
+    setSignupStatus({ msg: "", ok: null });
     setEmailRemainSec(0);
-
-    setUserName("");
     setPassword("");
     setPassword2("");
-    setSignupStatus({ msg: "", ok: null });
+
+    const prevState = (window.history.state ?? {}) as SignupHistoryState;
+    window.history.replaceState(
+      {
+        ...prevState,
+        signupForm: {
+          ...initialFormState,
+          signUpType: type,
+        },
+      },
+      ""
+    );
   };
 
   const startSignupFlow = (type: SignUpType) => {
-    setSignUpType(type);
-    resetForm();
+    resetForm(type);
   };
 
   const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
 
-  const allChecked = agreements.service && agreements.privacy && agreements.push;
-  const requiredChecked = agreements.service && agreements.privacy;
-
-  const passwordMatched =
-    password.length > 0 || password2.length > 0 ? password === password2 : null;
-
   const validateStep = () => {
-    if (step === 1) {
+    if (form.step === 1) {
       if (!requiredChecked) {
         return { ok: false, field: "terms", msg: "필수 약관에 동의해주세요." };
       }
       return { ok: true };
     }
 
-    if (step === 2 && signUpType === "ENTERPRISE" && !bNoVerified) {
+    if (form.step === 2 && form.signUpType === "ENTERPRISE" && !form.bNoVerified) {
       return { ok: false, field: "bNo", msg: "사업자 인증이 필요합니다." };
     }
 
-    if (step === 3 && signUpType === "ENTERPRISE" && !cautionAgreed) {
+    if (form.step === 3 && form.signUpType === "ENTERPRISE" && !form.cautionAgreed) {
       return { ok: false, field: "caution", msg: "유의사항에 동의해주세요." };
     }
 
-    if (step === 4 && !phoneVerified) {
+    if (form.step === 4 && !form.phoneVerified) {
       return { ok: false, field: "phone", msg: "본인인증을 완료해주세요." };
     }
 
-    if (step === 5 && !emailVerified) {
+    if (form.step === 5 && !form.emailVerified) {
       return { ok: false, field: "email", msg: "이메일 인증을 완료해주세요." };
     }
 
@@ -211,55 +278,49 @@ export default function Signup() {
     const result = validateStep();
 
     if (!result.ok) {
-      if (result.field === "terms") {
-        setSignupStatus({ msg: "", ok: null });
-      }
-      if (result.field === "bNo") {
-        setBNoStatus({ msg: result.msg!, ok: false });
-      }
-      if (result.field === "caution") {
-        setCautionStatus({ msg: result.msg!, ok: false });
-      }
-      if (result.field === "phone") {
-        setPhoneStatus({ msg: result.msg!, ok: false });
-      }
-      if (result.field === "email") {
-        setEmailVerifyStatus({ msg: result.msg!, ok: false });
-      }
+      if (result.field === "bNo") setBNoStatus({ msg: result.msg!, ok: false });
+      if (result.field === "caution") setCautionStatus({ msg: result.msg!, ok: false });
+      if (result.field === "phone") setPhoneStatus({ msg: result.msg!, ok: false });
+      if (result.field === "email") setEmailVerifyStatus({ msg: result.msg!, ok: false });
       return;
     }
 
-    if (signUpType === "PERSONAL") {
-      if (step === 1) setStep(4);
-      else if (step < 7) setStep((prev) => prev + 1);
-    } else {
-      if (step < 7) setStep((prev) => prev + 1);
-    }
+    setForm((prev) => {
+      if (prev.signUpType === "PERSONAL") {
+        if (prev.step === 1) return { ...prev, step: 4 };
+        if (prev.step < 7) return { ...prev, step: prev.step + 1 };
+        return prev;
+      }
+
+      if (prev.step < 7) return { ...prev, step: prev.step + 1 };
+      return prev;
+    });
 
     window.scrollTo({ top: 0, behavior: "smooth" });
   };
 
   const mockPhoneVerify = () => {
-    const onlyNumber = phone.replace(/\D/g, "");
+    const onlyNumber = form.phone.replace(/\D/g, "");
     if (onlyNumber.length < 10) {
       setPhoneStatus({ msg: "휴대폰 번호를 입력해주세요.", ok: false });
       return;
     }
-    setPhoneVerified(true);
+
+    updateForm("phoneVerified", true);
     setPhoneStatus({ msg: "본인인증이 완료되었습니다.", ok: true });
   };
 
   const onBnoChange = (value: string) => {
-    setBNo(value.replace(/\D/g, "").slice(0, 10));
-    setBNoVerified(false);
+    updateForm("bNo", value.replace(/\D/g, "").slice(0, 10));
+    updateForm("bNoVerified", false);
     setBNoStatus({ msg: "", ok: null });
   };
 
   const verifyBno = async () => {
-    const cleaned = bNo.replace(/\D/g, "");
+    const cleaned = form.bNo.replace(/\D/g, "");
     if (cleaned.length !== 10) {
       setBNoStatus({ msg: "10자리(숫자)만 입력해주세요.", ok: false });
-      setBNoVerified(false);
+      updateForm("bNoVerified", false);
       return;
     }
 
@@ -272,14 +333,14 @@ export default function Signup() {
       })) as EnterpriseVerifyResponse;
 
       const ok = !!result?.verified;
-      setBNoVerified(ok);
+      updateForm("bNoVerified", ok);
       setBNoStatus({
         msg: result?.message || (ok ? "인증되었습니다." : "인증 실패"),
         ok,
       });
     } catch (error) {
       console.error("사업자 인증 실패:", error);
-      setBNoVerified(false);
+      updateForm("bNoVerified", false);
       setBNoStatus({ msg: "사업자 인증에 실패했습니다.", ok: false });
     } finally {
       setLoading((prev) => ({ ...prev, enterpriseVerify: false }));
@@ -287,43 +348,57 @@ export default function Signup() {
   };
 
   const sendEmailCode = async () => {
-    setEmailVerified(false);
     setEmailVerifyStatus({ msg: "", ok: null });
 
-    if (!email.trim()) {
+    if (!form.email.trim()) {
       setEmailSendStatus({ msg: "이메일을 입력해주세요.", ok: false });
       return;
     }
-    if (!isValidEmail(email.trim())) {
+
+    if (!isValidEmail(form.email.trim())) {
       setEmailSendStatus({ msg: "유효한 이메일 주소를 입력해주세요.", ok: false });
       return;
     }
 
-    setLoading((prev) => ({ ...prev, emailSend: true }));
-    setEmailSendStatus({ msg: "전송 중...", ok: null });
+    const expireAt = Date.now() + EMAIL_EXPIRE_SEC * 1000;
+
+    setForm((prev) => ({
+      ...prev,
+      emailVerified: false,
+      emailExpireAt: expireAt,
+    }));
+    setEmailRemainSec(EMAIL_EXPIRE_SEC);
+    setEmailSendStatus({ msg: "인증번호를 발송했습니다. 메일을 확인해주세요.", ok: true });
 
     try {
       await apiClient.post("/api/auth/email/verification", {
-        email: email.trim(),
+        email: form.email.trim(),
       });
-
-      setEmailSendStatus({ msg: "인증번호가 메일로 발송되었습니다.", ok: true });
-      setEmailRemainSec(EMAIL_EXPIRE_SEC);
     } catch (error) {
       console.error("이메일 인증번호 발송 실패:", error);
-      setEmailSendStatus({ msg: "인증번호 발송에 실패했습니다.", ok: false });
+
+      if (emailTimerRef.current) {
+        window.clearInterval(emailTimerRef.current);
+        emailTimerRef.current = null;
+      }
+
+      setForm((prev) => ({
+        ...prev,
+        emailExpireAt: null,
+        emailVerified: false,
+      }));
       setEmailRemainSec(0);
-    } finally {
-      setLoading((prev) => ({ ...prev, emailSend: false }));
+      setEmailSendStatus({ msg: "인증번호 발송에 실패했습니다.", ok: false });
     }
   };
 
   const confirmEmailCode = async () => {
-    if (!email.trim()) {
+    if (!form.email.trim()) {
       setEmailVerifyStatus({ msg: "이메일을 먼저 입력해주세요.", ok: false });
       return;
     }
-    if (!emailCode.trim()) {
+
+    if (!form.emailCode.trim()) {
       setEmailVerifyStatus({ msg: "인증번호를 입력해주세요.", ok: false });
       return;
     }
@@ -333,8 +408,8 @@ export default function Signup() {
 
     try {
       await apiClient.post("/api/auth/email/verification/confirmation", {
-        email: email.trim(),
-        code: emailCode.trim(),
+        email: form.email.trim(),
+        code: form.emailCode.trim(),
       });
 
       if (emailTimerRef.current) {
@@ -342,13 +417,17 @@ export default function Signup() {
         emailTimerRef.current = null;
       }
 
-      setEmailVerified(true);
+      setForm((prev) => ({
+        ...prev,
+        emailVerified: true,
+        emailExpireAt: null,
+      }));
       setEmailVerifyStatus({ msg: "인증되었습니다.", ok: true });
-      setEmailSendStatus({ msg: "", ok: null }); // 만료 문구 제거
+      setEmailSendStatus({ msg: "", ok: null });
       setEmailRemainSec(0);
     } catch (error) {
       console.error("이메일 인증 확인 실패:", error);
-      setEmailVerified(false);
+      updateForm("emailVerified", false);
       setEmailVerifyStatus({ msg: "인증번호가 일치하지 않습니다.", ok: false });
     } finally {
       setLoading((prev) => ({ ...prev, emailConfirm: false }));
@@ -358,25 +437,30 @@ export default function Signup() {
   const submitSignUp = async () => {
     setSignupStatus({ msg: "", ok: null });
 
-    if (!emailVerified || !phoneVerified || passwordMatched !== true) {
+    if (!form.emailVerified || !form.phoneVerified || passwordMatched !== true) {
       setSignupStatus({ msg: "입력값과 인증 상태를 다시 확인해주세요.", ok: false });
       return;
     }
 
-    if (!userName.trim()) {
+    if (!form.userName.trim()) {
       setSignupStatus({ msg: "이름을 입력해주세요.", ok: false });
       return;
     }
 
+    if (!passwordValidation.isValid) {
+      setSignupStatus({ msg: passwordValidation.message, ok: false });
+      return;
+    }
+
     const payload: SignUpPayload = {
-      userName: userName.trim(),
-      email: email.trim(),
+      userName: form.userName.trim(),
+      email: form.email.trim(),
       password,
-      phoneNumber: phone.replace(/\D/g, ""),
+      phoneNumber: form.phone.replace(/\D/g, ""),
     };
 
-    if (signUpType === "ENTERPRISE") {
-      payload.brn = bNo.replace(/\D/g, "");
+    if (form.signUpType === "ENTERPRISE") {
+      payload.brn = form.bNo.replace(/\D/g, "");
     }
 
     setLoading((prev) => ({ ...prev, signup: true }));
@@ -384,7 +468,19 @@ export default function Signup() {
 
     try {
       await apiClient.post("/api/auth/signup", payload);
-      setStep(7);
+
+      const prevState = (window.history.state ?? {}) as SignupHistoryState;
+      window.history.replaceState(
+        {
+          ...prevState,
+          signupForm: undefined,
+        },
+        ""
+      );
+
+      setPassword("");
+      setPassword2("");
+      setForm((prev) => ({ ...prev, step: 7, emailExpireAt: null }));
       window.scrollTo({ top: 0, behavior: "smooth" });
     } catch (error) {
       console.error("회원가입 실패:", error);
@@ -394,7 +490,7 @@ export default function Signup() {
     }
   };
 
-  const renderStatus = (status: { msg: string; ok: boolean | null }) => {
+  const renderStatus = (status: StatusState) => {
     if (!status.msg) return <div className="min-h-[20px] mt-2" />;
 
     const color =
@@ -413,431 +509,111 @@ export default function Signup() {
     );
   };
 
-  const labelClassName = "block mb-2 text-[14px] font-semibold text-gray-900";
-
-  if (!signUpType) {
+  if (!form.signUpType) {
     return (
-      <main className="flex-1 flex flex-col min-h-[calc(80vh-var(--spacing-header-height))] items-center py-10 pt-30 bg-gray-50">
-        <div className="w-full max-w-[520px] bg-white p-10 rounded-[var(--radius-m)] shadow-[0_4px_24px_rgba(0,0,0,0.06)] border border-gray-100">
-          <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">회원가입</h2>
-          <p className="text-center text-[14px] text-gray-500 mb-8">
-            가입하실 회원 유형을 선택해주세요
-          </p>
-
-          <button
-            type="button"
-            onClick={() => startSignupFlow("PERSONAL")}
-            className="w-full p-6 border border-gray-200 rounded-[12px] flex items-center gap-5 bg-white mb-4 text-left hover:border-green-500 transition-colors"
-          >
-            <div className="w-14 h-14 bg-gray-50 rounded-full flex items-center justify-center">
-              <PersonalUser className="w-8 h-8" />
-            </div>
-            <div>
-              <h4 className="text-[17px] font-bold text-gray-900 mb-1">개인 회원</h4>
-              <p className="text-[14px] text-gray-500">일반 투자 및 서비스를 이용하는 개인</p>
-            </div>
-          </button>
-
-          <button
-            type="button"
-            onClick={() => startSignupFlow("ENTERPRISE")}
-            className="w-full p-6 border border-gray-200 rounded-[12px] flex items-center gap-5 bg-white text-left hover:border-green-500 transition-colors"
-          >
-            <div className="w-14 h-14 bg-gray-50 rounded-full flex items-center justify-center">
-              <EnterpriseUser className="w-8 h-8" />
-            </div>
-            <div>
-              <h4 className="text-[17px] font-bold text-gray-900 mb-1">기업 회원</h4>
-              <p className="text-[14px] text-gray-500">법인 및 사업자 명의 투자 서비스 이용</p>
-            </div>
-          </button>
-
-          <div className="mt-6 text-center text-[14px] text-gray-500">
-            이미 회원이신가요?{" "}
-            <button
-              type="button"
-              onClick={() => navigate("/auth/login")}
-              className="text-green-600 font-bold"
-            >
-              로그인
-            </button>
-          </div>
-        </div>
-      </main>
+      <SignupSelect
+        onSelect={startSignupFlow}
+        onGoLogin={() => navigate("/auth/login")}
+      />
     );
   }
 
   return (
-    <main className="flex-1 flex flex-col items-center py-10 bg-gray-50">
+    <main className="flex-1 flex flex-col items-center py-10 bg-gray-50 min-h-[calc(75vh-var(--spacing-header-height))]">
       <div className="w-full max-w-[520px]">
-        <div className="flex justify-center gap-3 mb-8">
-          {Array.from({ length: totalSteps }).map((_, idx) => (
-            <div
-              key={idx}
-              className={`h-2 rounded-full transition-all ${
-                currentDotIndex === idx + 1 ? "w-6 bg-green-600" : "w-2 bg-gray-300"
-              }`}
-            />
-          ))}
-        </div>
+        <SignupProgress
+          totalSteps={totalSteps}
+          currentDotIndex={currentDotIndex}
+        />
 
-        <div className="bg-white p-10 rounded-[12px] shadow-[0_4px_24px_rgba(0,0,0,0.06)] border border-gray-100">
-          {step === 1 && (
-            <section>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">약관 동의</h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                원활한 서비스 이용을 위해 약관에 동의해주세요
-              </p>
+        {form.step === 1 && (
+          <SignupAgreeStep
+            agreements={form.agreements}
+            allChecked={allChecked}
+            onToggleAll={(checked) =>
+              updateForm("agreements", {
+                service: checked,
+                privacy: checked,
+                push: checked,
+              })
+            }
+            onToggleOne={(key, checked) =>
+              updateForm("agreements", {
+                ...form.agreements,
+                [key]: checked,
+              })
+            }
+            onNext={goToNext}
+          />
+        )}
 
-              <div className="border border-gray-200 rounded-[8px] p-5">
-                <label className="flex items-center gap-2 pb-4 border-b border-gray-200 mb-4 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={allChecked}
-                    onChange={(e) =>
-                      setAgreements({
-                        service: e.target.checked,
-                        privacy: e.target.checked,
-                        push: e.target.checked,
-                      })
-                    }
-                  />
-                  <span className="font-bold text-gray-900">약관 전체 동의</span>
-                </label>
+        {form.signUpType === "PERSONAL" && form.step >= 4 && (
+          <SignupPersonalStep
+            form={form}
+            updateForm={updateForm}
+            goToNext={goToNext}
+            phoneStatus={phoneStatus}
+            emailSendStatus={emailSendStatus}
+            emailVerifyStatus={emailVerifyStatus}
+            signupStatus={signupStatus}
+            password={password}
+            password2={password2}
+            passwordMatched={passwordMatched}
+            passwordValidation={passwordValidation}
+            emailRemainSec={emailRemainSec}
+            loading={{
+              emailConfirm: loading.emailConfirm,
+              signup: loading.signup,
+            }}
+            setPassword={setPassword}
+            setPassword2={setPassword2}
+            setPhoneStatus={setPhoneStatus}
+            setEmailSendStatus={setEmailSendStatus}
+            setEmailVerifyStatus={setEmailVerifyStatus}
+            setSignupStatus={setSignupStatus}
+            mockPhoneVerify={mockPhoneVerify}
+            sendEmailCode={sendEmailCode}
+            confirmEmailCode={confirmEmailCode}
+            submitSignUp={submitSignUp}
+            formatMMSS={formatMMSS}
+            renderStatus={renderStatus}
+          />
+        )}
 
-                <label className="flex items-center gap-2 mt-4 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={agreements.service}
-                    onChange={(e) =>
-                      setAgreements((prev) => ({ ...prev, service: e.target.checked }))
-                    }
-                  />
-                  <span>[필수] 서비스 이용약관 동의</span>
-                </label>
-
-                <label className="flex items-center gap-2 mt-4 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={agreements.privacy}
-                    onChange={(e) =>
-                      setAgreements((prev) => ({ ...prev, privacy: e.target.checked }))
-                    }
-                  />
-                  <span>[필수] 개인정보 수집 및 이용 동의</span>
-                </label>
-
-                <label className="flex items-center gap-2 mt-4 cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={agreements.push}
-                    onChange={(e) =>
-                      setAgreements((prev) => ({ ...prev, push: e.target.checked }))
-                    }
-                  />
-                  <span>[선택] 푸시 알람 수신 동의</span>
-                </label>
-              </div>
-
-              <div className="pb-10" />
-
-              <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
-                다음으로
-              </Button>
-            </section>
-          )}
-
-          {step === 2 && signUpType === "ENTERPRISE" && (
-            <section>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">기업 인증</h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                사업자 등록번호를 확인합니다
-              </p>
-
-              <div className="mb-5">
-                <label className={labelClassName}>사업자 등록번호</label>
-                <div className="flex gap-2">
-                  <Input
-                    type="text"
-                    value={bNo}
-                    onChange={(e) => onBnoChange(e.target.value)}
-                    placeholder="숫자만 입력 (10자리)"
-                    maxLength={10}
-                    height={50}
-                  />
-                  <button
-                    type="button"
-                    className="px-5 h-[50px] bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
-                    onClick={verifyBno}
-                    disabled={loading.enterpriseVerify}
-                  >
-                    {loading.enterpriseVerify ? "조회 중..." : "인증하기"}
-                  </button>
-                </div>
-                {renderStatus(bNoStatus)}
-              </div>
-
-              <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
-                다음으로
-              </Button>
-            </section>
-          )}
-
-          {step === 3 && signUpType === "ENTERPRISE" && (
-            <section>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">유의사항 확인</h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                법인회원 거래 유의사항을 확인해주세요
-              </p>
-
-              <div className="bg-gray-50 border border-gray-200 p-5 rounded-[8px] text-[13px] h-[150px] overflow-y-auto mb-6 text-gray-600 leading-6">
-                <h4 className="font-bold mb-3">[법인회원 고객확인 거래 유의사항]</h4>
-                1. 자금세탁방지 의무 준수
-                <br />
-                2. 정보 제공의 정확성 보장
-                <br />
-                3. 실소유주 정보 제공 의무
-              </div>
-
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={cautionAgreed}
-                  onChange={(e) => {
-                    setCautionAgreed(e.target.checked);
-                    setCautionStatus({ msg: "", ok: null });
-                  }}
-                />
-                <span className="font-bold text-gray-900">
-                  위 내용을 모두 확인하였으며 동의합니다.
-                </span>
-              </label>
-
-              {renderStatus(cautionStatus)}
-
-              <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
-                다음으로
-              </Button>
-            </section>
-          )}
-
-          {step === 4 && (
-            <section>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">본인 확인</h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                휴대폰 본인인증을 진행합니다
-              </p>
-
-              <div className="mb-3">
-                <label className={labelClassName}>휴대폰 번호</label>
-                <Input
-                  type="text"
-                  value={phone}
-                  onChange={(e) => {
-                    setPhone(e.target.value.replace(/\D/g, ""));
-                    setPhoneVerified(false);
-                    setPhoneStatus({ msg: "", ok: null });
-                  }}
-                  placeholder="01012345678"
-                  height={50}
-                />
-                {renderStatus(phoneStatus)}
-              </div>
-
-              <div className="mb-4">
-                <button
-                  type="button"
-                  className="w-full h-[50px] rounded-[8px] font-semibold border border-green-600 text-green-600"
-                  onClick={mockPhoneVerify}
-                >
-                  본인인증 완료하기 (PASS 연동)
-                </button>
-                <p className="mt-2 text-[12px] text-gray-500 text-center">
-                  * 현재 테스트 모드로 즉시 인증됩니다.
-                </p>
-              </div>
-
-              <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
-                다음으로
-              </Button>
-            </section>
-          )}
-
-          {step === 5 && (
-            <section>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">이메일 인증</h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                로그인 아이디로 사용할 이메일을 인증하세요
-              </p>
-
-              <div className="mb-5">
-                <label className={labelClassName}>이메일 주소 (ID)</label>
-                <div className="flex gap-2">
-                  <div className="relative flex-1">
-                    <Input
-                      type="email"
-                      value={email}
-                      onChange={(e) => {
-                        setEmail(e.target.value);
-                        setEmailVerified(false);
-                        setEmailSendStatus({ msg: "", ok: null });
-                        setEmailVerifyStatus({ msg: "", ok: null });
-                      }}
-                      placeholder="example@farm.com"
-                      className="pr-20"
-                      height={50}
-                    />
-                    {emailRemainSec > 0 && (
-                      <span className="absolute right-4 top-1/2 -translate-y-1/2 text-[14px] text-red-500 font-semibold">
-                        {formatMMSS(emailRemainSec)}
-                      </span>
-                    )}
-                  </div>
-                  <button
-                    type="button"
-                    className="px-5 h-[50px] bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
-                    onClick={sendEmailCode}
-                    disabled={loading.emailSend}
-                  >
-                    {loading.emailSend ? "전송 중..." : emailRemainSec > 0 ? "재전송" : "인증요청"}
-                  </button>
-                </div>
-                {renderStatus(emailSendStatus)}
-              </div>
-
-              <div className="mb-5">
-                <label className={labelClassName}>인증번호</label>
-                <div className="flex gap-2">
-                  <Input
-                    type="text"
-                    value={emailCode}
-                    onChange={(e) => {
-                      setEmailCode(e.target.value);
-                      setEmailVerifyStatus({ msg: "", ok: null });
-                    }}
-                    placeholder="인증번호 6자리"
-                    height={50}
-                  />
-                  <button
-                    type="button"
-                    className="px-5 h-[50px] bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
-                    onClick={confirmEmailCode}
-                    disabled={loading.emailConfirm}
-                  >
-                    {loading.emailConfirm ? "확인 중..." : "확인"}
-                  </button>
-                </div>
-                {renderStatus(emailVerifyStatus)}
-              </div>
-
-              <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
-                다음으로
-              </Button>
-            </section>
-          )}
-
-          {step === 6 && (
-            <section>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">회원정보 입력</h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                가입 정보를 확인하고 비밀번호를 설정하세요
-              </p>
-
-              <div className="mb-5">
-                <label className={labelClassName}>이름</label>
-                <Input
-                  type="text"
-                  value={userName}
-                  onChange={(e) => {
-                    setUserName(e.target.value);
-                    setSignupStatus({ msg: "", ok: null });
-                  }}
-                  placeholder="이름 입력"
-                  height={50}
-                />
-              </div>
-
-              <div className="mb-5">
-                <label className={labelClassName}>이메일 (ID)</label>
-                <Input type="text" value={email} readOnly className="!bg-gray-100" height={50} />
-              </div>
-
-              {signUpType === "ENTERPRISE" && (
-                <div className="mb-5">
-                  <label className={labelClassName}>사업자 등록번호</label>
-                  <Input type="text" value={bNo} readOnly className="!bg-gray-100" height={50} />
-                </div>
-              )}
-
-              <div className="mb-5">
-                <label className={labelClassName}>비밀번호</label>
-                <Input
-                  type="password"
-                  value={password}
-                  onChange={(e) => {
-                    setPassword(e.target.value);
-                    setSignupStatus({ msg: "", ok: null });
-                  }}
-                  placeholder="비밀번호"
-                  height={50}
-                />
-              </div>
-
-              <div className="mb-5">
-                <label className={labelClassName}>비밀번호 확인</label>
-                <Input
-                  type="password"
-                  value={password2}
-                  onChange={(e) => {
-                    setPassword2(e.target.value);
-                    setSignupStatus({ msg: "", ok: null });
-                  }}
-                  placeholder="비밀번호 재입력"
-                  height={50}
-                />
-                {renderStatus(
-                  passwordMatched === null
-                    ? { msg: "", ok: null }
-                    : passwordMatched
-                      ? { msg: "비밀번호가 일치합니다.", ok: true }
-                      : { msg: "비밀번호가 일치하지 않습니다.", ok: false }
-                )}
-              </div>
-
-              {renderStatus(signupStatus)}
-
-              <Button
-                type="button"
-                variant="check"
-                width="100%"
-                height={50}
-                onClick={submitSignUp}
-                disabled={loading.signup}
-              >
-                {loading.signup ? "가입 처리 중..." : "가입 완료하기"}
-              </Button>
-            </section>
-          )}
-
-          {step === 7 && (
-            <section className="text-center py-10">
-              <div className="text-[64px] mb-6 text-green-600">🌿</div>
-              <h2 className="text-center text-[24px] font-bold text-gray-900 mb-3">
-                가입을 축하드립니다!
-              </h2>
-              <p className="text-center text-[14px] text-gray-500 mb-8">
-                로그인 페이지로 이동하여 서비스를 이용해보세요.
-              </p>
-              <button
-                type="button"
-                className="w-full h-[50px] rounded-[8px] bg-green-600 text-white font-semibold"
-                onClick={() => navigate("/auth/login")}
-              >
-                로그인하러 가기
-              </button>
-            </section>
-          )}
-        </div>
+        {form.signUpType === "ENTERPRISE" && form.step >= 2 && (
+          <SignupEnterpriseStep
+            form={form}
+            updateForm={updateForm}
+            goToNext={goToNext}
+            bNoStatus={bNoStatus}
+            cautionStatus={cautionStatus}
+            phoneStatus={phoneStatus}
+            emailSendStatus={emailSendStatus}
+            emailVerifyStatus={emailVerifyStatus}
+            signupStatus={signupStatus}
+            password={password}
+            password2={password2}
+            passwordMatched={passwordMatched}
+            passwordValidation={passwordValidation}
+            emailRemainSec={emailRemainSec}
+            loading={loading}
+            setPassword={setPassword}
+            setPassword2={setPassword2}
+            setCautionStatus={setCautionStatus}
+            setPhoneStatus={setPhoneStatus}
+            setEmailSendStatus={setEmailSendStatus}
+            setEmailVerifyStatus={setEmailVerifyStatus}
+            setSignupStatus={setSignupStatus}
+            onBnoChange={onBnoChange}
+            verifyBno={verifyBno}
+            mockPhoneVerify={mockPhoneVerify}
+            sendEmailCode={sendEmailCode}
+            confirmEmailCode={confirmEmailCode}
+            submitSignUp={submitSignUp}
+            formatMMSS={formatMMSS}
+            renderStatus={renderStatus}
+          />
+        )}
       </div>
     </main>
   );

--- a/frontend/src/pages/Auth/components/LoginForm.tsx
+++ b/frontend/src/pages/Auth/components/LoginForm.tsx
@@ -21,7 +21,7 @@ export default function LoginForm({
   onSubmit,
 }: LoginFormProps) {
   return (
-    <div className="flex flex-col items-center px-6 pt-30 min-h-[calc(80vh-var(--spacing-header-height))] bg-gray-50">
+    <div className="flex flex-col items-center px-6 pt-20 min-h-[calc(75vh-var(--spacing-header-height))] bg-gray-50">
       
       <AuthCard
         title="로그인"

--- a/frontend/src/pages/Auth/components/SignupAgreeStep.tsx
+++ b/frontend/src/pages/Auth/components/SignupAgreeStep.tsx
@@ -1,0 +1,79 @@
+import AuthCard from "@/components/common/AuthCard";
+import Button from "@/components/common/Button";
+
+type Agreements = {
+  service: boolean;
+  privacy: boolean;
+  push: boolean;
+};
+
+type SignupTermsStepProps = {
+  agreements: Agreements;
+  allChecked: boolean;
+  onToggleAll: (checked: boolean) => void;
+  onToggleOne: (key: keyof Agreements, checked: boolean) => void;
+  onNext: () => void;
+};
+
+export default function SignupTermsStep({
+  agreements,
+  allChecked,
+  onToggleAll,
+  onToggleOne,
+  onNext,
+}: SignupTermsStepProps) {
+  return (
+    <AuthCard
+      title="약관 동의"
+      description="원활한 서비스 이용을 위해 약관에 동의해주세요"
+    >
+      <div className="border border-gray-200 rounded-[8px] p-5">
+        <label className="flex items-center gap-2 pb-4 border-b border-gray-200 mb-4 cursor-pointer font-normal">
+          <input
+            type="checkbox"
+            checked={allChecked}
+            onChange={(e) => onToggleAll(e.target.checked)}
+            className="w-4 h-4 accent-(--color-green-600) shrink-0 cursor-pointer"
+          />
+          <span className="font-bold text-gray-900">약관 전체 동의</span>
+        </label>
+
+        <label className="flex items-center gap-2 mt-4 cursor-pointer font-normal">
+          <input
+            type="checkbox"
+            checked={agreements.service}
+            onChange={(e) => onToggleOne("service", e.target.checked)}
+            className="w-4 h-4 accent-(--color-green-600) shrink-0 cursor-pointer"
+          />
+          <span className="text-gray-900">[필수] 서비스 이용약관 동의</span>
+        </label>
+
+        <label className="flex items-center gap-2 mt-4 cursor-pointer font-normal">
+          <input
+            type="checkbox"
+            checked={agreements.privacy}
+            onChange={(e) => onToggleOne("privacy", e.target.checked)}
+            className="w-4 h-4 accent-(--color-green-600) shrink-0 cursor-pointer"
+          />
+          <span className="text-gray-900">[필수] 개인정보 수집 및 이용 동의</span>
+        </label>
+
+        <label className="flex items-center gap-2 mt-4 cursor-pointer font-normal">
+          <input
+            type="checkbox"
+            checked={agreements.push}
+            onChange={(e) => onToggleOne("push", e.target.checked)}
+            className="w-4 h-4 accent-(--color-green-600) shrink-0 cursor-pointer"
+          />
+          <span className="text-gray-900">[선택] 푸시 알람 수신 동의</span>
+        </label>
+      </div>
+
+      <div className="pb-10" />
+
+      <Button type="button" variant="check" width="100%" height={50} onClick={onNext}>
+        다음으로
+      </Button>
+    </AuthCard>
+  );
+}

--- a/frontend/src/pages/Auth/components/SignupEnterpriseStep.tsx
+++ b/frontend/src/pages/Auth/components/SignupEnterpriseStep.tsx
@@ -1,0 +1,184 @@
+import AuthCard from "@/components/common/AuthCard";
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import SignupPersonalStep, {
+  type FormState,
+  type StatusState,
+} from "./SignupPersonalStep";
+
+type SignupEnterpriseStepProps = {
+  form: FormState;
+  updateForm: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  goToNext: () => void;
+  bNoStatus: StatusState;
+  cautionStatus: StatusState;
+  phoneStatus: StatusState;
+  emailSendStatus: StatusState;
+  emailVerifyStatus: StatusState;
+  signupStatus: StatusState;
+  password: string;
+  password2: string;
+  passwordMatched: boolean | null;
+  passwordValidation: {
+    isValid: boolean;
+    message: string;
+  };
+  emailRemainSec: number;
+  loading: {
+    enterpriseVerify: boolean;
+    emailConfirm: boolean;
+    signup: boolean;
+  };
+  setPassword: (value: string) => void;
+  setPassword2: (value: string) => void;
+  setCautionStatus: (status: StatusState) => void;
+  setPhoneStatus: (status: StatusState) => void;
+  setEmailSendStatus: (status: StatusState) => void;
+  setEmailVerifyStatus: (status: StatusState) => void;
+  setSignupStatus: (status: StatusState) => void;
+  onBnoChange: (value: string) => void;
+  verifyBno: () => void;
+  mockPhoneVerify: () => void;
+  sendEmailCode: () => void;
+  confirmEmailCode: () => void;
+  submitSignUp: () => void;
+  formatMMSS: (sec: number) => string;
+  renderStatus: (status: StatusState) => React.ReactNode;
+};
+
+export default function SignupEnterpriseStep({
+  form,
+  updateForm,
+  goToNext,
+  bNoStatus,
+  cautionStatus,
+  phoneStatus,
+  emailSendStatus,
+  emailVerifyStatus,
+  signupStatus,
+  password,
+  password2,
+  passwordMatched,
+  passwordValidation,
+  emailRemainSec,
+  loading,
+  setPassword,
+  setPassword2,
+  setCautionStatus,
+  setPhoneStatus,
+  setEmailSendStatus,
+  setEmailVerifyStatus,
+  setSignupStatus,
+  onBnoChange,
+  verifyBno,
+  mockPhoneVerify,
+  sendEmailCode,
+  confirmEmailCode,
+  submitSignUp,
+  formatMMSS,
+  renderStatus,
+}: SignupEnterpriseStepProps) {
+  const labelClassName = "block mb-2 text-[14px] font-semibold text-gray-900";
+
+  if (form.step === 2) {
+    return (
+      <AuthCard title="기업 인증" description="사업자 등록번호를 확인합니다">
+        <div className="mb-5">
+          <label className={labelClassName}>사업자 등록번호</label>
+          <div className="flex gap-2">
+            <Input
+              type="text"
+              value={form.bNo}
+              onChange={(e) => onBnoChange(e.target.value)}
+              placeholder="숫자만 입력 (10자리)"
+              maxLength={10}
+              height={50}
+            />
+            <button
+              type="button"
+              className="px-5 h-[50px] bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
+              onClick={verifyBno}
+              disabled={loading.enterpriseVerify}
+            >
+              {loading.enterpriseVerify ? "조회 중..." : "인증하기"}
+            </button>
+          </div>
+          {renderStatus(bNoStatus)}
+        </div>
+
+        <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
+          다음으로
+        </Button>
+      </AuthCard>
+    );
+  }
+
+  if (form.step === 3) {
+    return (
+      <AuthCard title="유의사항 확인" description="법인회원 거래 유의사항을 확인해주세요">
+        <div className="bg-gray-50 border border-gray-200 p-5 rounded-[8px] text-[13px] h-[150px] overflow-y-auto mb-6 text-gray-600 leading-6">
+          <h4 className="font-bold mb-3">[법인회원 고객확인 거래 유의사항]</h4>
+          1. 자금세탁방지 의무 준수
+          <br />
+          2. 정보 제공의 정확성 보장
+          <br />
+          3. 실소유주 정보 제공 의무
+        </div>
+
+        <label className="flex items-center gap-2 cursor-pointer font-normal">
+          <input
+            type="checkbox"
+            checked={form.cautionAgreed}
+            onChange={(e) => {
+              updateForm("cautionAgreed", e.target.checked);
+              setCautionStatus({ msg: "", ok: null });
+            }}
+            className="w-4 h-4 accent-(--color-green-600) shrink-0 cursor-pointer"
+          />
+          <span className="font-bold text-gray-900">
+            위 내용을 모두 확인하였으며 동의합니다.
+          </span>
+        </label>
+
+        {renderStatus(cautionStatus)}
+
+        <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
+          다음으로
+        </Button>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <SignupPersonalStep
+      form={form}
+      updateForm={updateForm}
+      goToNext={goToNext}
+      phoneStatus={phoneStatus}
+      emailSendStatus={emailSendStatus}
+      emailVerifyStatus={emailVerifyStatus}
+      signupStatus={signupStatus}
+      password={password}
+      password2={password2}
+      passwordMatched={passwordMatched}
+      passwordValidation={passwordValidation}
+      emailRemainSec={emailRemainSec}
+      loading={{
+        emailConfirm: loading.emailConfirm,
+        signup: loading.signup,
+      }}
+      setPassword={setPassword}
+      setPassword2={setPassword2}
+      setPhoneStatus={setPhoneStatus}
+      setEmailSendStatus={setEmailSendStatus}
+      setEmailVerifyStatus={setEmailVerifyStatus}
+      setSignupStatus={setSignupStatus}
+      mockPhoneVerify={mockPhoneVerify}
+      sendEmailCode={sendEmailCode}
+      confirmEmailCode={confirmEmailCode}
+      submitSignUp={submitSignUp}
+      formatMMSS={formatMMSS}
+      renderStatus={renderStatus}
+    />
+  );
+}

--- a/frontend/src/pages/Auth/components/SignupPersonalStep.tsx
+++ b/frontend/src/pages/Auth/components/SignupPersonalStep.tsx
@@ -1,0 +1,316 @@
+import type { ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import AuthCard from "@/components/common/AuthCard";
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+
+export type SignUpType = "PERSONAL" | "ENTERPRISE" | null;
+
+export type StatusState = {
+  msg: string;
+  ok: boolean | null;
+};
+
+export type FormState = {
+  signUpType: SignUpType;
+  step: number;
+  agreements: {
+    service: boolean;
+    privacy: boolean;
+    push: boolean;
+  };
+  bNo: string;
+  bNoVerified: boolean;
+  cautionAgreed: boolean;
+  phone: string;
+  phoneVerified: boolean;
+  email: string;
+  emailCode: string;
+  emailVerified: boolean;
+  emailExpireAt: number | null;
+  userName: string;
+};
+
+type SignupPersonalStepProps = {
+  form: FormState;
+  updateForm: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  goToNext: () => void;
+  phoneStatus: StatusState;
+  emailSendStatus: StatusState;
+  emailVerifyStatus: StatusState;
+  signupStatus: StatusState;
+  password: string;
+  password2: string;
+  passwordMatched: boolean | null;
+  passwordValidation: {
+    isValid: boolean;
+    message: string;
+  };
+  emailRemainSec: number;
+  loading: {
+    emailConfirm: boolean;
+    signup: boolean;
+  };
+  setPassword: (value: string) => void;
+  setPassword2: (value: string) => void;
+  setPhoneStatus: (status: StatusState) => void;
+  setEmailSendStatus: (status: StatusState) => void;
+  setEmailVerifyStatus: (status: StatusState) => void;
+  setSignupStatus: (status: StatusState) => void;
+  mockPhoneVerify: () => void;
+  sendEmailCode: () => void;
+  confirmEmailCode: () => void;
+  submitSignUp: () => void;
+  formatMMSS: (sec: number) => string;
+  renderStatus: (status: StatusState) => ReactNode;
+};
+
+export default function SignupPersonalStep({
+  form,
+  updateForm,
+  goToNext,
+  phoneStatus,
+  emailSendStatus,
+  emailVerifyStatus,
+  signupStatus,
+  password,
+  password2,
+  passwordMatched,
+  passwordValidation,
+  emailRemainSec,
+  loading,
+  setPassword,
+  setPassword2,
+  setPhoneStatus,
+  setEmailSendStatus,
+  setEmailVerifyStatus,
+  setSignupStatus,
+  mockPhoneVerify,
+  sendEmailCode,
+  confirmEmailCode,
+  submitSignUp,
+  formatMMSS,
+  renderStatus,
+}: SignupPersonalStepProps) {
+  const navigate = useNavigate();
+
+  const labelClassName = "block mb-2 text-[14px] font-semibold text-gray-900";
+
+  if (form.step === 4) {
+    return (
+      <AuthCard title="본인 확인" description="휴대폰 본인인증을 진행합니다">
+        <div className="mb-3">
+          <label className={labelClassName}>휴대폰 번호</label>
+          <Input
+            type="text"
+            value={form.phone}
+            onChange={(e) => {
+              updateForm("phone", e.target.value.replace(/\D/g, ""));
+              updateForm("phoneVerified", false);
+              setPhoneStatus({ msg: "", ok: null });
+            }}
+            placeholder="01012345678"
+            height={50}
+          />
+          {renderStatus(phoneStatus)}
+        </div>
+
+        <div className="mb-4">
+          <button
+            type="button"
+            className="w-full h-[50px] rounded-[8px] font-semibold border border-green-600 text-green-600"
+            onClick={mockPhoneVerify}
+          >
+            본인인증 완료하기 (PASS 연동)
+          </button>
+          <p className="mt-2 text-[12px] text-gray-500 text-center">
+            * 현재 테스트 모드로 즉시 인증됩니다.
+          </p>
+        </div>
+
+        <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
+          다음으로
+        </Button>
+      </AuthCard>
+    );
+  }
+
+  if (form.step === 5) {
+    return (
+      <AuthCard title="이메일 인증" description="로그인 아이디로 사용할 이메일을 인증하세요">
+        <div className="mb-5">
+          <label className={labelClassName}>이메일 주소 (ID)</label>
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Input
+                type="email"
+                value={form.email}
+                onChange={(e) => {
+                  updateForm("email", e.target.value);
+                  updateForm("emailVerified", false);
+                  updateForm("emailExpireAt", null);
+                  setEmailSendStatus({ msg: "", ok: null });
+                  setEmailVerifyStatus({ msg: "", ok: null });
+                }}
+                placeholder="example@farm.com"
+                className="pr-20"
+                height={50}
+              />
+              {emailRemainSec > 0 && (
+                <span className="absolute right-4 top-1/2 -translate-y-1/2 text-[14px] text-red-500 font-semibold">
+                  {formatMMSS(emailRemainSec)}
+                </span>
+              )}
+            </div>
+            <button
+              type="button"
+              className="px-5 h-[50px] bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
+              onClick={sendEmailCode}
+            >
+              {emailRemainSec > 0 ? "재전송" : "인증요청"}
+            </button>
+          </div>
+          {renderStatus(emailSendStatus)}
+        </div>
+
+        <div className="mb-5">
+          <label className={labelClassName}>인증번호</label>
+          <div className="flex gap-2">
+            <Input
+              type="text"
+              value={form.emailCode}
+              onChange={(e) => {
+                updateForm("emailCode", e.target.value);
+                setEmailVerifyStatus({ msg: "", ok: null });
+              }}
+              placeholder="인증번호 6자리"
+              height={50}
+            />
+            <button
+              type="button"
+              className="px-5 h-[50px] bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
+              onClick={confirmEmailCode}
+              disabled={loading.emailConfirm}
+            >
+              {loading.emailConfirm ? "확인 중..." : "확인"}
+            </button>
+          </div>
+          {renderStatus(emailVerifyStatus)}
+        </div>
+
+        <Button type="button" variant="check" width="100%" height={50} onClick={goToNext}>
+          다음으로
+        </Button>
+      </AuthCard>
+    );
+  }
+
+  if (form.step === 6) {
+    return (
+      <AuthCard title="회원정보 입력" description="가입 정보를 확인하고 비밀번호를 설정하세요">
+        <div className="mb-5">
+          <label className={labelClassName}>이름</label>
+          <Input
+            type="text"
+            value={form.userName}
+            onChange={(e) => {
+              updateForm("userName", e.target.value);
+              setSignupStatus({ msg: "", ok: null });
+            }}
+            placeholder="이름 입력"
+            height={50}
+          />
+        </div>
+
+        <div className="mb-5">
+          <label className={labelClassName}>이메일 (ID)</label>
+          <Input type="text" value={form.email} readOnly className="!bg-gray-100" height={50} />
+        </div>
+
+        {form.signUpType === "ENTERPRISE" && (
+          <div className="mb-5">
+            <label className={labelClassName}>사업자 등록번호</label>
+            <Input type="text" value={form.bNo} readOnly className="!bg-gray-100" height={50} />
+          </div>
+        )}
+
+        <div className="mb-5">
+          <label className={labelClassName}>비밀번호</label>
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => {
+              setPassword(e.target.value);
+              setSignupStatus({ msg: "", ok: null });
+            }}
+            placeholder="비밀번호"
+            height={50}
+          />
+          {renderStatus(
+            password.length === 0
+              ? { msg: "", ok: null }
+              : passwordValidation.isValid
+                ? { msg: passwordValidation.message, ok: true }
+                : { msg: passwordValidation.message, ok: false }
+          )}
+        </div>
+
+        <div className="mb-5">
+          <label className={labelClassName}>비밀번호 확인</label>
+          <Input
+            type="password"
+            value={password2}
+            onChange={(e) => {
+              setPassword2(e.target.value);
+              setSignupStatus({ msg: "", ok: null });
+            }}
+            placeholder="비밀번호 재입력"
+            height={50}
+          />
+          {renderStatus(
+            passwordMatched === null
+              ? { msg: "", ok: null }
+              : passwordMatched
+                ? { msg: "비밀번호가 일치합니다.", ok: true }
+                : { msg: "비밀번호가 일치하지 않습니다.", ok: false }
+          )}
+        </div>
+
+        {renderStatus(signupStatus)}
+
+        <Button
+          type="button"
+          variant="check"
+          width="100%"
+          height={50}
+          onClick={submitSignUp}
+          disabled={loading.signup}
+        >
+          {loading.signup ? "가입 처리 중..." : "가입 완료하기"}
+        </Button>
+      </AuthCard>
+    );
+  }
+
+  if (form.step === 7) {
+    return (
+      <AuthCard
+        title="가입을 축하드립니다!"
+        description="로그인 페이지로 이동하여 서비스를 이용해보세요."
+      >
+        <section className="text-center py-10">
+          <div className="text-[64px] mb-6 text-green-600">🌿</div>
+          <button
+            type="button"
+            className="w-full h-[50px] rounded-[8px] bg-green-600 text-white font-semibold"
+            onClick={() => navigate("/auth/login")}
+          >
+            로그인하러 가기
+          </button>
+        </section>
+      </AuthCard>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/pages/Auth/components/SignupProgress.tsx
+++ b/frontend/src/pages/Auth/components/SignupProgress.tsx
@@ -1,0 +1,22 @@
+type SignupProgressProps = {
+  totalSteps: number;
+  currentDotIndex: number;
+};
+
+export default function SignupProgress({
+  totalSteps,
+  currentDotIndex,
+}: SignupProgressProps) {
+  return (
+    <div className="flex justify-center gap-3 mb-8">
+      {Array.from({ length: totalSteps }).map((_, idx) => (
+        <div
+          key={idx}
+          className={`h-2 rounded-full transition-all ${
+            currentDotIndex === idx + 1 ? "w-6 bg-green-600" : "w-2 bg-gray-300"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/Auth/components/SignupSelect.tsx
+++ b/frontend/src/pages/Auth/components/SignupSelect.tsx
@@ -1,0 +1,62 @@
+import AuthCard from "@/components/common/AuthCard";
+import { EnterpriseUser, PersonalUser } from "@/components/icon/Icons";
+
+type SignUpType = "PERSONAL" | "ENTERPRISE";
+
+type SignupTypeSelectProps = {
+  onSelect: (type: SignUpType) => void;
+  onGoLogin: () => void;
+};
+
+export default function SignupTypeSelect({
+  onSelect,
+  onGoLogin,
+}: SignupTypeSelectProps) {
+  return (
+    <main className="flex-1 flex flex-col min-h-[calc(75vh-var(--spacing-header-height))] items-center py-10 pt-20 bg-gray-50">
+      <AuthCard
+        title="회원가입"
+        description="가입하실 회원 유형을 선택해주세요"
+      >
+        <button
+          type="button"
+          onClick={() => onSelect("PERSONAL")}
+          className="w-full p-6 border border-gray-200 rounded-[12px] flex items-center gap-5 bg-white mb-4 text-left hover:border-green-500 transition-colors"
+        >
+          <div className="w-14 h-14 bg-gray-50 rounded-full flex items-center justify-center">
+            <PersonalUser size={32} color="#000000" />
+          </div>
+          <div>
+            <h4 className="text-[17px] font-bold text-gray-900 mb-1">개인 회원</h4>
+            <p className="text-[14px] text-gray-500">일반 투자 및 서비스를 이용하는 개인</p>
+          </div>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => onSelect("ENTERPRISE")}
+          className="w-full p-6 border border-gray-200 rounded-[12px] flex items-center gap-5 bg-white text-left hover:border-green-500 transition-colors"
+        >
+          <div className="w-14 h-14 bg-gray-50 rounded-full flex items-center justify-center">
+            <EnterpriseUser size={32} color="#000000" />
+          </div>
+          <div>
+            <h4 className="text-[17px] font-bold text-gray-900 mb-1">기업 회원</h4>
+            <p className="text-[14px] text-gray-500">법인 및 사업자 명의 투자 서비스 이용</p>
+          </div>
+        </button>
+
+        <div className="mt-6 text-center text-[14px] text-gray-500">
+          이미 회원이신가요?{" "}
+          <button
+            type="button"
+            onClick={onGoLogin}
+            className="text-green-600 font-bold"
+          >
+            로그인
+          </button>
+        </div>
+      </AuthCard>
+    </main>
+  );
+}

--- a/frontend/src/pages/Auth/hook/passwordValidation.ts
+++ b/frontend/src/pages/Auth/hook/passwordValidation.ts
@@ -1,0 +1,61 @@
+export type PasswordValidationResult = {
+  isValid: boolean;
+  message: string;
+  hasLetter: boolean;
+  hasNumber: boolean;
+  hasSpecial: boolean;
+  combinationCount: number;
+};
+
+export function validatePassword(password: string): PasswordValidationResult {
+  const hasLetter = /[A-Za-z]/.test(password);
+  const hasNumber = /[0-9]/.test(password);
+  const hasSpecial = /[^A-Za-z0-9]/.test(password);
+
+  const combinationCount = [hasLetter, hasNumber, hasSpecial].filter(Boolean).length;
+
+  if (combinationCount < 2) {
+    return {
+      isValid: false,
+      message:
+        "비밀번호는 영문, 숫자, 특수문자 중 2종류 이상을 조합해야 합니다.",
+      hasLetter,
+      hasNumber,
+      hasSpecial,
+      combinationCount,
+    };
+  }
+
+  if (combinationCount === 2 && password.length < 10) {
+    return {
+      isValid: false,
+      message:
+        "비밀번호는 영문, 숫자, 특수문자 중 2종류 조합 시 10자 이상이어야 합니다.",
+      hasLetter,
+      hasNumber,
+      hasSpecial,
+      combinationCount,
+    };
+  }
+
+  if (combinationCount >= 3 && password.length < 8) {
+    return {
+      isValid: false,
+      message:
+        "비밀번호는 영문, 숫자, 특수문자 중 3종류 이상 조합 시 8자 이상이어야 합니다.",
+      hasLetter,
+      hasNumber,
+      hasSpecial,
+      combinationCount,
+    };
+  }
+
+  return {
+    isValid: true,
+    message: "사용 가능한 비밀번호입니다.",
+    hasLetter,
+    hasNumber,
+    hasSpecial,
+    combinationCount,
+  };
+}


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 회원 가입 파트에서 step 기반 UI를 컴포넌트로 분리했습니다.
- 비밀번호 유효성 검사 로직을 추가했습니다.
    - 영문 / 숫자 / 특수문자 조합 규칙 적용
    - 2종류 조합: 10자 이상
    - 3종류 이상 조합: 8자 이상
  - `passwordValidation.ts`로 로직 분리
  
## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 회원가입 시 비밀번호를 입력할 때 사진입니다. | <img width="471" height="647" alt="image" src="https://github.com/user-attachments/assets/7824c7e0-0720-4308-8051-4c5d2405557c" />|


## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
