### PR TITLE
[FEAT] 토큰 재발급 로직 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 import './styles/index.css';
 import Header from './components/layout/Header';
@@ -22,6 +23,32 @@ import CarbonLayout from './pages/mypage/components/myCarbon/CarbonLayout';
 import ProjectList from './pages/project/ProjectList';
 
 function App() {
+  useEffect(() => {
+    let lastSavedTime = 0;
+
+    const updateActivity = () => {
+      const token = localStorage.getItem("accessToken");
+      if (!token) return;
+
+      const now = Date.now();
+      if (now - lastSavedTime < 30000) return;
+
+      localStorage.setItem("lastActivityTime", String(now));
+      lastSavedTime = now;
+    };
+
+    const events = ["click", "keydown", "scroll"];
+
+    events.forEach((event) => {
+      window.addEventListener(event, updateActivity);
+    });
+
+    return () => {
+      events.forEach((event) => {
+        window.removeEventListener(event, updateActivity);
+      });
+    };
+  }, []);
   return (
     <div className="flex flex-col min-h-screen">
       <Header />

--- a/frontend/src/api/apiClient.ts
+++ b/frontend/src/api/apiClient.ts
@@ -11,6 +11,61 @@ const apiClient = axios.create({
   },
 });
 
+// refresh 중복 호출 방지용
+let isRefreshing = false;
+let refreshSubscribers: ((token: string) => void)[] = [];
+
+const subscribeTokenRefresh = (callback: (token: string) => void) => {
+  refreshSubscribers.push(callback);
+};
+
+const onRefreshed = (newAccessToken: string) => {
+  refreshSubscribers.forEach((callback) => callback(newAccessToken));
+  refreshSubscribers = [];
+};
+
+const clearAuthStorage = () => {
+  localStorage.removeItem('accessToken');
+  localStorage.removeItem('refreshToken');
+  localStorage.removeItem('loginStartTime');
+  localStorage.removeItem('lastActivityTime');
+  localStorage.removeItem('userName');
+  localStorage.removeItem('userRole');
+};
+
+const moveToLogin = () => {
+  clearAuthStorage();
+  window.location.href = '/auth/login';
+};
+
+const refreshAccessToken = async () => {
+  const refreshToken = localStorage.getItem('refreshToken');
+
+  if (!refreshToken) {
+    throw new Error('리프레시 토큰이 없습니다.');
+  }
+
+  // 같은 apiClient 말고 axios 직접 사용
+  const response = await axios.post(
+    `${baseURL}/api/auth/refresh`,
+    { refreshToken },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      timeout: 10000,
+    },
+  );
+
+  const res = response.data;
+
+  if (!res.success) {
+    throw new Error(res.message || '토큰 재발급에 실패했습니다.');
+  }
+
+  return res.data;
+};
+
 // 2. 요청 인터셉터
 apiClient.interceptors.request.use((config) => {
   const token = localStorage.getItem('accessToken');
@@ -37,33 +92,78 @@ apiClient.interceptors.response.use(
       const errorMsg = res.message || '요청 처리에 실패했습니다.';
       console.error(errorMsg);
 
-      const error = new Error(errorMsg);
-      error.response = response;
-      return Promise.reject(error);
+      const customError = new Error(errorMsg) as Error & {
+        response?: typeof response;
+      };
+      customError.response = response;
+      return Promise.reject(customError);
     }
 
     return res.data;
   },
-  (error) => {
+
+  async (error) => {
     const res = error.response?.data; // ApiResponseDTO { success, message, data, error }
+    const originalRequest = error.config;
 
     if (res && !res.success) {
       const errorCode = res.error.code;
       const errorMsg = res.message;
 
       switch (errorCode) {
-        case 'AUTH_002': // NEED_LOGIN ("로그인이 필요한 서비스입니다.")
-        case 'AUTH_003': // EXPIRED_TOKEN ("로그인 정보가 만료되었습니다. 다시 로그인해주세요.")
+        case 'AUTH_002':
+        case 'AUTH_003': {
+          if (originalRequest?.url?.includes('/api/auth/refresh')) {
+            console.error(errorMsg);
+            moveToLogin();
+            return Promise.reject(error);
+          }
+
+          if (originalRequest?._retry) {
+            console.error(errorMsg);
+            moveToLogin();
+            return Promise.reject(error);
+          }
+
+          originalRequest._retry = true;
+
+          try {
+            if (isRefreshing) {
+              return new Promise((resolve) => {
+                subscribeTokenRefresh((newAccessToken: string) => {
+                  originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+                  resolve(apiClient(originalRequest));
+                });
+              });
+            }
+
+            isRefreshing = true;
+
+            const tokenData = await refreshAccessToken();
+
+            localStorage.setItem('accessToken', tokenData.accessToken);
+            localStorage.setItem('refreshToken', tokenData.refreshToken);
+            localStorage.setItem('lastActivityTime', String(Date.now()));
+
+            originalRequest.headers.Authorization = `Bearer ${tokenData.accessToken}`;
+
+            onRefreshed(tokenData.accessToken);
+            return apiClient(originalRequest);
+          } catch (refreshError) {
+            refreshSubscribers = [];
+            console.error('토큰 재발급 실패:', refreshError);
+            moveToLogin();
+            return Promise.reject(refreshError);
+          } finally {
+            isRefreshing = false;
+          }
+        }
+
+        case 'EXTERNAL_001': // 외부 API 에러
           console.error(errorMsg);
-          localStorage.removeItem('accessToken');
-          window.location.href = '/auth/login';
           break;
 
-        case 'EXTERNAL_001': // 외부 API 에러 ("외부 서비스 연동 중 오류가 발생했습니다.")
-          console.error(errorMsg);
-          break;
-
-        case 'PROJECT_002': // 별(하트) 처리 실패 ("별(하트) 처리 중 오류가 발생했습니다.")
+        case 'PROJECT_002': // 별(하트) 처리 실패
           console.error('관심 프로젝트 처리 실패:', errorMsg);
           break;
 

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { authApi } from "@/api/authApi.ts";
 import Icon from "@/components/icon";
+import userSession from "@/pages/Auth/hook/userSession";
 
 export default function Header() {
   const location = useLocation();
@@ -11,6 +12,8 @@ export default function Header() {
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
+  const { sessionExpireText } = userSession();
+
   // 컴포넌트 마운트 시 로그인 상태 및 사용자 정보 초기화
   useEffect(() => {
     // 1. 로컬 스토리지에서 액세스 토큰 불러오기
@@ -19,6 +22,8 @@ export default function Header() {
 
     if (!token) {
       setIsLogIn(false);
+      setUserName("");
+      setUserRole("");
       return;
     }
 
@@ -271,7 +276,14 @@ export default function Header() {
                   </button>
                 </div>
               </div>
-              <span className="font-button-02 text-gray-700">{userName} 님</span>
+              <div className="leading-tight">
+                <span className="pr-2 font-button-02 text-gray-700">
+                  {userName} 님
+                </span>
+                <span className="mt-0.5 text-[14px] text-gray-700">
+                    {sessionExpireText}
+                </span>
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/pages/Auth/Signup.tsx
+++ b/frontend/src/pages/Auth/Signup.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import apiClient from "@/api/apiClient";
-import { CheckCircle, WarningCircle } from "@/components/icon/Icons";
 import SignupAgreeStep from "./components/SignupAgreeStep";
 import SignupProgress from "./components/SignupProgress";
 import SignupSelect from "./components/SignupSelect";
@@ -502,8 +501,6 @@ export default function Signup() {
 
     return (
       <div className={`min-h-[20px] mt-2 flex items-center gap-2 text-[13px] font-medium ${color}`}>
-        {status.ok === true && <CheckCircle className="w-4 h-4 shrink-0" />}
-        {status.ok === false && <WarningCircle className="w-4 h-4 shrink-0" />}
         <span>{status.msg}</span>
       </div>
     );

--- a/frontend/src/pages/Auth/hook/userSession.tsx
+++ b/frontend/src/pages/Auth/hook/userSession.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useMemo, useState } from "react";
+
+const LOGOUT_TIME = 3 * 60 * 60 * 1000; // 3시간
+
+function formatRemain(ms: number) {
+  const totalSec = Math.max(Math.floor(ms / 1000), 0);
+  const hour = Math.floor(totalSec / 3600);
+  const min = Math.floor((totalSec % 3600) / 60);
+  const sec = totalSec % 60;
+
+  if (hour > 0) {
+    return `${String(hour).padStart(2, "0")}:${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+  }
+
+  return `${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+}
+
+export default function useSessionExpireText() {
+  const [remainMs, setRemainMs] = useState(0);
+
+  useEffect(() => {
+    const updateRemain = () => {
+      const lastActivityTime = Number(localStorage.getItem("lastActivityTime") || 0);
+
+      if (!lastActivityTime) {
+        setRemainMs(0);
+        return;
+      }
+
+      const expireAt = lastActivityTime + LOGOUT_TIME;
+      const remain = Math.max(expireAt - Date.now(), 0);
+      setRemainMs(remain);
+    };
+
+    updateRemain();
+    const timer = window.setInterval(updateRemain, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  const sessionExpireText = useMemo(() => {
+    if (remainMs <= 0) return "세션 만료";
+    return ` ${formatRemain(remainMs)}`;
+  }, [remainMs]);
+
+  return {
+    remainMs,
+    sessionExpireText,
+    isExpired: remainMs <= 0,
+  };
+}

--- a/frontend/src/pages/Auth/hook/userSession.tsx
+++ b/frontend/src/pages/Auth/hook/userSession.tsx
@@ -15,21 +15,40 @@ function formatRemain(ms: number) {
   return `${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
 }
 
+function forceLogout() {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("refreshToken");
+  localStorage.removeItem("loginStartTime");
+  localStorage.removeItem("lastActivityTime");
+  localStorage.removeItem("userName");
+  localStorage.removeItem("userRole");
+}
+
 export default function useSessionExpireText() {
   const [remainMs, setRemainMs] = useState(0);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     const updateRemain = () => {
+      const token = localStorage.getItem("accessToken");
       const lastActivityTime = Number(localStorage.getItem("lastActivityTime") || 0);
 
-      if (!lastActivityTime) {
+      if (!token) {
         setRemainMs(0);
+        setIsInitialized(true);
+        return;
+      }
+
+      if (!lastActivityTime) {
+        setRemainMs(LOGOUT_TIME); // 최소한 첫 진입 즉시 만료 처리하지 않음
+        setIsInitialized(true);
         return;
       }
 
       const expireAt = lastActivityTime + LOGOUT_TIME;
       const remain = Math.max(expireAt - Date.now(), 0);
       setRemainMs(remain);
+      setIsInitialized(true);
     };
 
     updateRemain();
@@ -40,14 +59,26 @@ export default function useSessionExpireText() {
     };
   }, []);
 
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+
+    if (!isInitialized) return;
+
+    if (token && remainMs <= 0) {
+      forceLogout();
+      window.location.href = "/auth/login";
+    }
+  }, [remainMs, isInitialized]);
+
   const sessionExpireText = useMemo(() => {
+    if (!isInitialized) return "";
     if (remainMs <= 0) return "세션 만료";
-    return ` ${formatRemain(remainMs)}`;
-  }, [remainMs]);
+    return formatRemain(remainMs);
+  }, [remainMs, isInitialized]);
 
   return {
     remainMs,
     sessionExpireText,
-    isExpired: remainMs <= 0,
+    isExpired: isInitialized && remainMs <= 0,
   };
 }


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 인증 만료 에러 코드가 오면 refresh token으로 /api/auth/refresh를 호출하도록 하였고, 재발급에 성공하면 새 access token을 저장하고, 방금 실패했던 요청의 헤더를 새 토큰으로 바꿔 자동 재시도 되도록 구현했습니다.
1. profile 요청 → 401
accessToken 만료 정상
2. refresh 요청 → 200
refreshToken으로 재발급 성공
3. profile 요청 → 200
새 accessToken으로 재요청 성공

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| access token을 짧게 설정해 테스트 해보고 요청이 일어난 사진입니다.| <img width="793" height="79" alt="image" src="https://github.com/user-attachments/assets/d0aca1f0-c54b-4dca-a2de-1221a65ca2f5" />|

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
