### PR TITLE
[FIX] Spring Security 인증 실패 응답 형식 통일

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/animalfarm/backend/config/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		// 정적 리소스 및 Swagger v3 경로는 필터를 거치지 않도록 설정 (성능 최적화)
 		return (web) -> web.ignoring()
-			.requestMatchers("/swagger-ui/**","/swagger-ui.html","/swagger-resources/**", "/v3/api-docs/**", "/v3/api-docs", "/webjars/**",
+			.requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/swagger-resources/**", "/v3/api-docs/**",
+				"/v3/api-docs", "/webjars/**",
 				"/resources/**", "/favicon.ico", "/error");
 	}
 
@@ -61,15 +62,15 @@ public class SecurityConfig {
 				.permitAll()
 				.requestMatchers("/project/**", "/token/**", "/token", "/carbon/**", "/mypage/**", "/market/**")
 				.permitAll()
-				.requestMatchers("/admin", "/admin/**")
-				.permitAll()
 
 				// [Read-Only] GET 요청에 대해 전역 허용
 				.requestMatchers(HttpMethod.GET, "/api/project/**", "/api/token/**", "/api/token", "/api/accounts/**",
-					"/api/market/**")
+					"/api/market/**", "/api/home/project")
 				.permitAll()
 
 				// [Role: ADMIN] 관리자 전용 기능
+				.requestMatchers("/admin", "/admin/**")
+				.hasRole("ADMIN")
 				.requestMatchers("/api/admin/**")
 				.hasRole("ADMIN")
 				.requestMatchers("/api/project/insert", "/api/project/update")

--- a/backend/src/main/java/com/animalfarm/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	INVALID_LOGOUT_REQUEST(HttpStatus.BAD_REQUEST, "AUTH_005", "잘못된 로그아웃 요청입니다."),
 	LOGOUT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH_006", "로그아웃 처리 중 오류가 발생했습니다."),
 	INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED, "AUTH_007", "이메일 인증 코드가 올바르지 않습니다."),
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_008", "접근 권한이 없습니다."),
 
 	// 시스템 에러
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_001", "서버 내부 오류가 발생했습니다."),

--- a/backend/src/main/java/com/animalfarm/backend/global/security/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/security/JwtAccessDeniedHandler.java
@@ -2,35 +2,46 @@ package com.animalfarm.backend.global.security;
 
 import java.io.IOException;
 
+import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
+import com.animalfarm.backend.global.dto.ApiResponseDTO;
+import com.animalfarm.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * [403 Forbidden 처리기]
- * - 로그인은 했지만 해당 리소스에 접근할 권한이 없는 경우(예: 관리자 페이지 접근) 호출됩니다.
- * - 자산 관리 권한이 없는 투자자의 접근을 차단하고 JSON 메시지를 보냅니다.
- */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
 	@Override
+	public void handle(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AccessDeniedException accessDeniedException
+	) throws IOException, ServletException {
 
-	public void handle(HttpServletRequest request, HttpServletResponse response,
-		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		log.error("권한 부족: {}", accessDeniedException.getMessage());
 
-		log.error("권한 부족: 접근 권한이 없습니다. - {}", accessDeniedException.getMessage());
-
-		// [보안 응답 설정] 클라이언트에게 403 에러를 JSON 형태로 전달합니다.
-		response.setContentType("application/json;charset=UTF-8");
 		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-		response.getWriter().println("{ \"error\": \"403\", \"message\": \"해당 리소스에 접근할 권한이 없습니다.\" }");
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
 
+		ApiResponseDTO<Void> body = ApiResponseDTO.fail(
+			ErrorCode.ACCESS_DENIED.getCode(),
+			ErrorCode.ACCESS_DENIED.getMessage()
+		);
+
+		response.getWriter().write(objectMapper.writeValueAsString(body));
 	}
-
 }

--- a/backend/src/main/java/com/animalfarm/backend/global/security/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/security/JwtAuthenticationEntryPoint.java
@@ -2,32 +2,46 @@ package com.animalfarm.backend.global.security;
 
 import java.io.IOException;
 
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
+
+import com.animalfarm.backend.global.dto.ApiResponseDTO;
+import com.animalfarm.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * [401 Unauthorized 에러 처리기]
- * - 인증되지 않은 사용자가 보호된 리소스에 접근할 때 호출됩니다.
- * - 스마트팜 STO 플랫폼에서 로그인이 필요한 서비스임을 클라이언트에게 명확히 알립니다.
- * - 스프링 시큐리티의 기본 에러 페이지 대신 커스텀 JSON 응답을 보냅니다.
- */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+	private final ObjectMapper objectMapper;
+
 	@Override
-	public void commence(HttpServletRequest request, HttpServletResponse response,
-		org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException, ServletException {
 
-		response.setContentType("application/json;charset=UTF-8");
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+		log.error("인증 실패: {}", authException.getMessage());
 
-		// 깔끔한 JSON 응답
-		response.getWriter().print("로그인이 필요한 서비스입니다.");
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+
+		ApiResponseDTO<Void> body = ApiResponseDTO.fail(
+			ErrorCode.NEED_LOGIN.getCode(),
+			ErrorCode.NEED_LOGIN.getMessage()
+		);
+
+		response.getWriter().write(objectMapper.writeValueAsString(body));
 	}
 }


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- Spring Security의 401 인증 실패 응답을 프론트 공통 응답 형식에 맞게 통일해, accessToken 만료 시 refreshToken 재발급 및 요청 재시도 로직이 정상 동작하도록 개선했습니다.
- 메인 페이지에 프로젝트 목록이 나오지 않던 현상을 해결, 관리자 페이지 관리자만 접속할 수 있도록 변경했습니다.
## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 응답 형식 통일 | <img width="1003" height="220" alt="image" src="https://github.com/user-attachments/assets/d16516e8-5589-4b7d-8ebe-a6afe639a370" /> |

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
