### PR TITLE
[FEAT] 비밀번호 찾기 페이지 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,8 @@ import WalletLayout from './pages/mypage/components/myWallet/WalletLayout';
 import TransactionLayout from './pages/mypage/components/myTransaction/TransactionLayout';
 import CarbonLayout from './pages/mypage/components/myCarbon/CarbonLayout';
 import ProjectList from './pages/project/ProjectList';
+import FindPassword from './pages/Auth/components/FindPassword';
+import ResetPassword from './pages/Auth/components/ResetPassword';
 
 function App() {
   useEffect(() => {
@@ -56,9 +58,12 @@ function App() {
       <main className="content-wrapper pb-16 md:pb-0">
         <ScrollToTop />
         <Routes>
-          <Route path="/" element={<Home />} />
+          <Route path="/"  element={<Home />} />
+          <Route path="/main"  element={<Navigate to="/" replace />} />
           <Route path="/auth/login" element={<Login />} />
           <Route path="/auth/signup" element={<Signup />} />
+          <Route path="/auth/find-password" element={<FindPassword/>} />
+          <Route path="/auth/reset-password" element={<ResetPassword/>} />
           <Route path="/project/:id" element={<ProjectDetail />} />
           <Route path="/project" element={<ProjectList />} />
           <Route path="/token" element={<TokenList />} />

--- a/frontend/src/api/authApi.ts
+++ b/frontend/src/api/authApi.ts
@@ -10,4 +10,23 @@ export const authApi = {
     getUserRole: () => {
         return apiClient.get("/api/user/me/role");
     },
+    sendPasswordResetCode: (email: string) => {
+        return apiClient.post("/api/auth/password/reset/code", { email });
+    },
+    verifyPasswordResetCode: (email: string, code: string) => {
+        return apiClient.post("/api/auth/password/reset/verify", { email, code });
+    },
+    resetPassword: (
+        email: string,
+        verificationCode: string,
+        newPassword: string,
+        confirmPassword: string,
+    ) => {
+        return apiClient.post("/api/auth/password/reset", {
+            email,
+            verificationCode,
+            newPassword,
+            confirmPassword,
+        });
+    },
 }

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -2,7 +2,7 @@ import {useState} from "react";
 import {useNavigate} from "react-router-dom";
 import apiClient from "@/api/apiClient";
 import {authApi} from "@/api/authApi";
-import LoginForm from "@/pages/auth/components/LoginForm.tsx";
+import LoginForm from "./components/LoginForm.tsx";
 
 type LoginResponse = {
     accessToken: string;

--- a/frontend/src/pages/Auth/components/FindPassword.tsx
+++ b/frontend/src/pages/Auth/components/FindPassword.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { authApi } from "@/api/authApi";
+import FindPasswordForm from "./FindPasswordForm";
+
+const EMAIL_EXPIRE_SEC = 300; // 5분
+
+export default function FindPassword() {
+  const navigate = useNavigate();
+  const emailTimerRef = useRef<number | null>(null);
+
+  const [email, setEmail] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+  const [emailMessage, setEmailMessage] = useState("");
+  const [isCodeVerified, setIsCodeVerified] = useState(false);
+  const [emailExpireAt, setEmailExpireAt] = useState<number | null>(null);
+  const [emailRemainSec, setEmailRemainSec] = useState(0);
+
+  const formatMMSS = (sec: number) => {
+    const m = String(Math.floor(sec / 60)).padStart(2, "0");
+    const s = String(sec % 60).padStart(2, "0");
+    return `${m}:${s}`;
+  };
+
+  useEffect(() => {
+    const expireAt = emailExpireAt;
+
+    if (!expireAt) {
+      if (emailTimerRef.current) {
+        window.clearInterval(emailTimerRef.current);
+        emailTimerRef.current = null;
+      }
+      return;
+    }
+
+    const updateRemain = () => {
+      const remain = Math.max(0, Math.floor((expireAt - Date.now()) / 1000));
+      setEmailRemainSec(remain);
+
+      if (remain <= 0) {
+        if (emailTimerRef.current) {
+          window.clearInterval(emailTimerRef.current);
+          emailTimerRef.current = null;
+        }
+
+        setEmailExpireAt(null);
+        setEmailRemainSec(0);
+        setEmailMessage("인증번호가 만료되었습니다. 재전송해주세요.");
+        setIsCodeVerified(false);
+      }
+    };
+
+    emailTimerRef.current = window.setInterval(updateRemain, 1000);
+
+    return () => {
+      if (emailTimerRef.current) {
+        window.clearInterval(emailTimerRef.current);
+        emailTimerRef.current = null;
+      }
+    };
+  }, [emailExpireAt]);
+
+  const handleSendCode = async () => {
+    setError("");
+    setSuccess("");
+    setEmailMessage("");
+    setIsCodeVerified(false);
+
+    if (!email) {
+      setError("이메일을 입력해주세요.");
+      return;
+    }
+
+    try {
+      await authApi.sendPasswordResetCode(email);
+      const expireAt = Date.now() + EMAIL_EXPIRE_SEC * 1000;
+      setEmailExpireAt(expireAt);
+      setEmailRemainSec(EMAIL_EXPIRE_SEC);
+      setEmailMessage("인증 코드가 발송되었습니다. 이메일을 확인해주세요.");
+    } catch (err) {
+      console.error("비밀번호 재설정 코드 발송 실패:", err);
+      setError("유효한 이메일을 입력하고 다시 시도해주세요.");
+    }
+  };
+
+  const handleVerifyCode = async () => {
+    setError("");
+    setSuccess("");
+
+    if (!email || !verificationCode) {
+      setError("이메일과 인증 코드를 모두 입력해주세요.");
+      return;
+    }
+
+    try {
+      await authApi.verifyPasswordResetCode(email, verificationCode);
+      setIsCodeVerified(true);
+      setSuccess("인증 코드가 확인되었습니다. 다음 단계로 이동하세요.");
+    } catch (err) {
+      console.error("인증 코드 확인 실패:", err);
+      setError("인증 코드가 올바르지 않습니다. 다시 확인해주세요.");
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+
+    if (!isCodeVerified) {
+      setError("인증 코드를 확인한 후 다음 단계로 이동해주세요.");
+      return;
+    }
+
+    navigate("/auth/reset-password", {
+      state: { email, verificationCode },
+    });
+  };
+
+  return (
+    <FindPasswordForm
+      email={email}
+      verificationCode={verificationCode}
+      error={error}
+      success={success}
+      emailMessage={emailMessage}
+      isCodeVerified={isCodeVerified}
+      emailRemainSec={emailRemainSec}
+      formatMMSS={formatMMSS}
+      onChangeEmail={setEmail}
+      onChangeVerificationCode={setVerificationCode}
+      onSendCode={handleSendCode}
+      onVerifyCode={handleVerifyCode}
+      onSubmit={handleSubmit}
+    />
+  );
+}

--- a/frontend/src/pages/Auth/components/FindPasswordForm.tsx
+++ b/frontend/src/pages/Auth/components/FindPasswordForm.tsx
@@ -1,0 +1,135 @@
+import { Link } from "react-router-dom";
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import AuthCard from "@/components/common/AuthCard";
+
+type FindPasswordFormProps = {
+  email: string;
+  verificationCode: string;
+  error: string;
+  success: string;
+  emailMessage: string;
+  isCodeVerified: boolean;
+  emailRemainSec: number;
+  formatMMSS: (sec: number) => string;
+  onChangeEmail: (value: string) => void;
+  onChangeVerificationCode: (value: string) => void;
+  onSendCode: () => void;
+  onVerifyCode: () => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+};
+
+export default function FindPasswordForm({
+  email,
+  verificationCode,
+  error,
+  success,
+  emailMessage,
+  isCodeVerified,
+  emailRemainSec,
+  formatMMSS,
+  onChangeEmail,
+  onChangeVerificationCode,
+  onSendCode,
+  onVerifyCode,
+  onSubmit,
+}: FindPasswordFormProps) {
+  return (
+    <div className="flex flex-col items-center px-6 py-10 min-h-[calc(75vh-var(--spacing-header-height))] bg-gray-50">
+      <AuthCard
+        title="비밀번호 찾기"
+        description="이메일 인증 후 새로운 비밀번호를 설정합니다"
+      >
+        <form onSubmit={onSubmit}>
+          {/* 이메일 */}
+          <div className="mb-5">
+            <label className="block text-[14px] font-bold text-gray-900 mb-2">
+              이메일 주소
+            </label>
+
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <Input
+                  type="email"
+                  placeholder="example@farmpiece.com"
+                  required
+                  value={email}
+                  onChange={(e) => onChangeEmail(e.target.value)}
+                  className="pr-20"
+                />
+                {emailRemainSec > 0 && (
+                  <span className="absolute right-4 top-1/2 -translate-y-1/2 text-[14px] text-red-500 font-semibold">
+                    {formatMMSS(emailRemainSec)}
+                  </span>
+                )}
+              </div>
+
+              <button
+                type="button"
+                className="px-5 h-12 bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
+                onClick={onSendCode}
+              >
+                {emailRemainSec > 0 ? "재전송" : "코드 발송"}
+              </button>
+            </div>
+            {emailMessage && (
+              <p className="mt-2 text-[14px] text-green-600">{emailMessage}</p>
+            )}
+          </div>
+
+          {/* 인증코드 */}
+          <div className="mb-10">
+            <label className="block text-[14px] font-bold text-gray-900 mb-2">
+              인증코드
+            </label>
+
+            <div className="flex gap-2">
+              <Input
+                type="text"
+                placeholder="인증코드를 입력하세요"
+                required
+                value={verificationCode}
+                onChange={(e) =>
+                  onChangeVerificationCode(e.target.value)
+                }
+                className="flex-1"
+              />
+
+              <button
+                type="button"
+                className="px-5 h-12 bg-gray-900 text-white rounded-[8px] font-semibold whitespace-nowrap"
+                onClick={onVerifyCode}
+                disabled={!verificationCode}
+              >
+                확인
+              </button>
+            </div>
+            {(error || success) && (
+              <p className={`mt-2 text-[14px] ${error ? "text-red-600" : "text-green-600"}`}>
+                {error || success}
+              </p>
+            )}
+          </div>
+
+          {/* 메인 버튼 (기존 유지) */}
+          <Button
+            variant="check"
+            width="100%"
+            type="submit"
+            disabled={!isCodeVerified}
+          >
+            다음
+          </Button>
+        </form>
+
+        {/* 하단 링크 */}
+        <div className="mt-8 text-center text-[14px] text-gray-500">
+          로그인 페이지로 돌아가시겠어요?
+          <Link to="/auth/login" className="ml-1 font-bold text-green-600">
+            로그인
+          </Link>
+        </div>
+      </AuthCard>
+    </div>
+  );
+}

--- a/frontend/src/pages/Auth/components/LoginForm.tsx
+++ b/frontend/src/pages/Auth/components/LoginForm.tsx
@@ -21,7 +21,7 @@ export default function LoginForm({
   onSubmit,
 }: LoginFormProps) {
   return (
-    <div className="flex flex-col items-center px-6 pt-20 min-h-[calc(75vh-var(--spacing-header-height))] bg-gray-50">
+    <div className="flex flex-col items-center px-6 py-10 min-h-[calc(75vh-var(--spacing-header-height))] bg-gray-50">
       
       <AuthCard
         title="로그인"
@@ -44,7 +44,7 @@ export default function LoginForm({
           </div>
 
           {/* 비밀번호 */}
-          <div className="mb-8">
+          <div className="mb-5">
             <label className="block text-[14px] font-bold text-gray-900 mb-2">
               비밀번호
             </label>
@@ -55,12 +55,12 @@ export default function LoginForm({
               value={password}
               onChange={(e) => onChangePassword(e.target.value)}
             />
+            <div className="min-h-[24px] mt-2">
+              {error && (
+                <p className="text-[14px] text-[#d32f2f]">{error}</p>
+              )}
+            </div>
           </div>
-
-          {/* 에러 */}
-          {error && (
-            <p className="mt-1 text-[14px] text-[#d32f2f]">{error}</p>
-          )}
 
           {/* 버튼 */}
           <Button variant="check" width="100%" type="submit">
@@ -73,6 +73,12 @@ export default function LoginForm({
           계정이 없으신가요?
           <Link to="/auth/signup" className="ml-1 font-bold text-green-600">
             회원가입
+          </Link>
+        </div>
+        <div className="mt-2 text-center text-[14px] text-gray-500">
+          비밀번호를 잊으셨나요?
+          <Link to="/auth/find-password" className="ml-1 font-bold text-green-600">
+            비밀번호 찾기
           </Link>
         </div>
       </AuthCard>

--- a/frontend/src/pages/Auth/components/ResetPassword.tsx
+++ b/frontend/src/pages/Auth/components/ResetPassword.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import Toast from "@/components/common/Toast";
+import ResetPasswordForm from "./ResetPasswordForm";
+import { authApi } from "@/api/authApi";
+import { validatePassword, type PasswordValidationResult } from "../hook/passwordValidation";
+
+type LocationState = {
+  email?: string;
+  verificationCode?: string;
+};
+
+export default function ResetPassword() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as LocationState | null;
+
+  const [email] = useState(state?.email ?? "");
+  const [verificationCode] = useState(state?.verificationCode ?? "");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  const passwordValidation = useMemo<PasswordValidationResult>(() => validatePassword(newPassword), [newPassword]);
+  const passwordMatched = confirmPassword.length > 0 ? newPassword === confirmPassword : null;
+
+  const handleNewPasswordChange = (value: string) => {
+    setNewPassword(value);
+    setError("");
+  };
+
+  const handleConfirmPasswordChange = (value: string) => {
+    setConfirmPassword(value);
+    setError("");
+  };
+
+  useEffect(() => {
+    if (!state?.email || !state?.verificationCode) {
+      navigate("/auth/find-password", { replace: true });
+    }
+  }, [navigate, state]);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError("");
+
+    if (!newPassword || !confirmPassword) {
+      setError("새 비밀번호와 확인 비밀번호를 모두 입력해주세요.");
+      return;
+    }
+
+    if (!passwordValidation.isValid) {
+      setError(passwordValidation.message);
+      return;
+    }
+
+    if (newPassword !== confirmPassword) {
+      setError("새 비밀번호와 확인 비밀번호가 일치하지 않습니다.");
+      return;
+    }
+
+    try {
+      await authApi.resetPassword(email, verificationCode, newPassword, confirmPassword);
+      setToastMessage("비밀번호가 성공적으로 변경되었습니다. 로그인 페이지로 이동합니다.");
+      window.setTimeout(() => {
+        navigate("/auth/login");
+      }, 1200);
+    } catch (err) {
+      console.error("비밀번호 재설정 실패:", err);
+      setError("비밀번호 변경에 실패했습니다. 다시 시도해주세요.");
+    }
+  };
+
+  return (
+    <>
+      <ResetPasswordForm
+        email={email}
+        newPassword={newPassword}
+        confirmPassword={confirmPassword}
+        error={error}
+        passwordValidation={passwordValidation}
+        passwordMatched={passwordMatched}
+        onChangeNewPassword={handleNewPasswordChange}
+        onChangeConfirmPassword={handleConfirmPasswordChange}
+        onSubmit={handleSubmit}
+      />
+      {toastMessage && (
+        <Toast message={toastMessage} onClose={() => setToastMessage(null)} />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Auth/components/ResetPasswordForm.tsx
+++ b/frontend/src/pages/Auth/components/ResetPasswordForm.tsx
@@ -1,0 +1,115 @@
+import { Link } from "react-router-dom";
+import Button from "@/components/common/Button";
+import Input from "@/components/common/Input";
+import AuthCard from "@/components/common/AuthCard";
+
+type ResetPasswordFormProps = {
+  email: string;
+  newPassword: string;
+  confirmPassword: string;
+  error: string;
+  passwordValidation: {
+    isValid: boolean;
+    message: string;
+  };
+  passwordMatched: boolean | null;
+  onChangeNewPassword: (value: string) => void;
+  onChangeConfirmPassword: (value: string) => void;
+  onSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
+};
+
+export default function ResetPasswordForm({
+  email,
+  newPassword,
+  confirmPassword,
+  error,
+  passwordValidation,
+  passwordMatched,
+  onChangeNewPassword,
+  onChangeConfirmPassword,
+  onSubmit,
+}: ResetPasswordFormProps) {
+  return (
+    <div className="flex flex-col items-center px-6 py-10 min-h-[calc(75vh-var(--spacing-header-height))] bg-gray-50">
+      <AuthCard
+        title="비밀번호 재설정"
+        description="이메일 인증 후 새 비밀번호를 설정하세요."
+      >
+        <form onSubmit={onSubmit}>
+          <div className="mb-5">
+            <label className="block text-[14px] font-bold text-gray-900 mb-2">
+              이메일 주소
+            </label>
+            <Input
+              type="email"
+              value={email}
+              readOnly
+              className="bg-gray-100 cursor-not-allowed"
+            />
+          </div>
+
+          <div className="mb-5">
+            <label className="block text-[14px] font-bold text-gray-900 mb-2">
+              새 비밀번호
+            </label>
+            <Input
+              type="password"
+              placeholder="새 비밀번호를 입력하세요"
+              required
+              value={newPassword}
+              onChange={(e) => onChangeNewPassword(e.target.value)}
+            />
+            <div className="mt-2">
+              {newPassword.length > 0 && (
+                <p
+                  className={`text-[14px] ${passwordValidation.isValid ? "text-green-600" : "text-red-600"}`}
+                >
+                  {passwordValidation.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="mb-5">
+            <label className="block text-[14px] font-bold text-gray-900 mb-2">
+              비밀번호 확인
+            </label>
+            <Input
+              type="password"
+              placeholder="비밀번호를 다시 입력하세요"
+              required
+              value={confirmPassword}
+              onChange={(e) => onChangeConfirmPassword(e.target.value)}
+            />
+            <div className="min-h-[24px] mt-2">
+              {passwordMatched !== null && (
+                <p
+                  className={`text-[14px] ${passwordMatched ? "text-green-600" : "text-red-600"}`}
+                >
+                  {passwordMatched ? "비밀번호가 일치합니다." : "비밀번호가 일치하지 않습니다."}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {error && (
+            <div className="mb-4">
+              <p className="text-[14px] text-red-600">{error}</p>
+            </div>
+          )}
+
+          <Button variant="check" width="100%" type="submit">
+            비밀번호 변경
+          </Button>
+        </form>
+
+        <div className="mt-8 text-center text-[14px] text-gray-500">
+          로그인 페이지로 돌아가시겠어요?
+          <Link to="/auth/login" className="ml-1 font-bold text-green-600">
+            로그인
+          </Link>
+        </div>
+      </AuthCard>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 비밀번호를 잊어버렸을 때 찾기 위한 페이지를 만들었습니다.

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 비밀번호 찾기 페이지 입니다 | <img width="524" height="524" alt="image" src="https://github.com/user-attachments/assets/7652d97d-37dd-449f-8714-67e7f405710d" />|
| 비밀번호 재설정 페이지 입니다 | <img width="534" height="633" alt="image" src="https://github.com/user-attachments/assets/1f21d6b3-c09a-4c5f-9aac-16a1b1a5f041" /> |

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
