### PR TITLE
[FEAT] 관리자 페이지 REACT 변환

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/domain/project/FarmService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/project/FarmService.java
@@ -82,16 +82,13 @@ public class FarmService {
 
 		Map<Long, String[]> farmMapping = new HashMap<>() {{
 			put(3L, new String[] {"PF_0000320_01", "080400"});   // 딸기
-			put(52L, new String[] {"PF_0000320_01", "080400"});
 			put(4L, new String[] {"PF_0022038_01", "061400"});   // 감귤
 			put(23L, new String[] {"PF_0006001_01", "065900"});   // 블루베리
 			put(12L, new String[] {"PF_0006027_01", "060300"});   // 포도
 			put(11L, new String[] {"PF_0006017_01", "120500"});  // 고추(11)
 			put(15L, new String[] {"PF_0006017_01", "120500"});  // 고추(15) - 같은 데이터 활용
-			put(53L, new String[] {"PF_0006017_01", "120500"});
 			put(19L, new String[] {"PF_0024647_01", "132600"});  // 파프리카
 			put(14L, new String[] {"PF_0025312_01", "080100"});   // 수박
-			put(54L, new String[] {"PF_0025312_01", "080100"});
 			put(35L, new String[] {"PFS_0000001_01", "080300"}); // 토마토
 
 			// 매칭 정보가 없는 ??? 농장들 (기본값 설정 - 토마토 데이터 활용 예시)

--- a/backend/src/main/java/com/animalfarm/backend/domain/project/ProjectService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/project/ProjectService.java
@@ -311,7 +311,7 @@ public class ProjectService {
 		}
 		return null;
 	}
-	
+
 	public List<ProjectDTO> selectEndTargetProject() {
 		return projectRepository.selectEndTargetProject();
 	}
@@ -336,6 +336,6 @@ public class ProjectService {
 			new ParameterizedTypeReference<ExternalApiResponseDTO<TokenIssueDTO>>() {
 			});
 
-		log.info("증권사 전송 성공 : " + result);
+		log.info("증권사 전송 성공 : " + tokenIssueDTO);
 	}
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,23 +21,30 @@ import WalletLayout from './pages/mypage/components/myWallet/WalletLayout';
 import TransactionLayout from './pages/mypage/components/myTransaction/TransactionLayout';
 import CarbonLayout from './pages/mypage/components/myCarbon/CarbonLayout';
 import ProjectList from './pages/project/ProjectList';
+import {
+  CultivationRegister,
+  ExpenseRegister,
+  FarmRegister,
+  ProjectRegister,
+  RevenueRegister,
+} from '@/pages/admin';
 
 function App() {
   useEffect(() => {
     let lastSavedTime = 0;
 
     const updateActivity = () => {
-      const token = localStorage.getItem("accessToken");
+      const token = localStorage.getItem('accessToken');
       if (!token) return;
 
       const now = Date.now();
       if (now - lastSavedTime < 30000) return;
 
-      localStorage.setItem("lastActivityTime", String(now));
+      localStorage.setItem('lastActivityTime', String(now));
       lastSavedTime = now;
     };
 
-    const events = ["click", "keydown", "scroll"];
+    const events = ['click', 'keydown', 'scroll'];
 
     events.forEach((event) => {
       window.addEventListener(event, updateActivity);
@@ -73,6 +80,11 @@ function App() {
             <Route path="transaction-history" element={<TransactionLayout />} />
             <Route path="carbon-history" element={<CarbonLayout />} />
           </Route>
+          <Route path="/admin/farm" element={<FarmRegister />} />
+          <Route path="/admin/project" element={<ProjectRegister />} />
+          <Route path="/admin/cultivation" element={<CultivationRegister />} />
+          <Route path="/admin/expense" element={<ExpenseRegister />} />
+          <Route path="/admin/revenue" element={<RevenueRegister />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>

--- a/frontend/src/api/adminApi.ts
+++ b/frontend/src/api/adminApi.ts
@@ -1,0 +1,104 @@
+import apiClient from './apiClient'; // 기존 http_client 재사용 (apiClient.ts로 가정)
+import axios from 'axios';
+
+export interface FarmData {
+  farmName: string;
+  farmType: string;
+  area: number;
+  openAt: string;
+  addressSido: string;
+  addressSigungu: string;
+  addressStreet: string;
+  latitude: number;
+  longitude: number;
+  altitude: number;
+  description?: string;
+}
+
+export interface ProjectData {
+  projectId?: number;
+  farmId: number;
+  projectName: string;
+  projectRound: number;
+  projectDescription?: string;
+  targetAmount: number;
+  minAmountPerInvestor: number;
+  expectedReturn: number;
+  managerCount: number;
+  announcementStartDate: string;
+  announcementEndDate: string;
+  subscriptionStartDate: string;
+  subscriptionEndDate: string;
+  resultAnnouncementDate: string;
+  projectStartDate: string;
+  projectEndDate: string;
+  projectImages?: File[];
+  deletedPictureIds?: number[];
+}
+
+export interface CultivationData {
+  projectId: number;
+  managerCount: number;
+  crop: string;
+  expectedYield: number;
+  actualYield?: number;
+  plantingDate: string;
+  harvestDate?: string;
+  notes?: string;
+}
+
+export interface ExpenseData {
+  projectId: number;
+  recordedBy: string;
+  category: string;
+  subCategory: string;
+  amount: number;
+  startDate: string;
+  endDate: string;
+  vendor: string;
+  description?: string;
+}
+
+export interface RevenueData {
+  projectId: number;
+  recordedBy: string;
+  startDate: string;
+  endDate: string;
+  amount: number;
+  description?: string;
+}
+
+export const adminApi = {
+  insertFarm: (data: FarmData) => apiClient.post('/farm/insert', data),
+  getCoords: (address: string) =>
+    apiClient.get(`/farm/get-coords?address=${encodeURIComponent(address)}`),
+  getFarms: async () => {
+    // /api/project/farm/all은 ApiResponseDTO 없이 직접 배열을 반환하므로 axios 직접 사용
+    const baseURL = import.meta.env.VITE_API_BASE_URL;
+    const token = localStorage.getItem('accessToken');
+    const response = await axios.get(`${baseURL}/api/project/farm/all`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
+    });
+    return response.data;
+  },
+  insertProject: (data: FormData) =>
+    apiClient.post('/api/project/insert', data),
+  updateProject: (data: FormData) =>
+    apiClient.post('/api/project/update', data),
+  getProjects: () => apiClient.get('/api/project/all'),
+  getProjectDetails: (projectId: number) =>
+    apiClient.get(`/api/project/${projectId}`),
+  getProjectPictures: (projectId: number) =>
+    apiClient.get(`/api/project/${projectId}/pictures`),
+  getTokens: (projectId: number) =>
+    apiClient.get(`/api/token/${projectId}`),
+  insertCultivation: (data: CultivationData) =>
+    apiClient.post('/api/cultivation/insert', data),
+  insertExpense: (data: ExpenseData) =>
+    apiClient.post('/api/expense/insert', data),
+  insertRevenue: (data: RevenueData) =>
+    apiClient.post('/api/revenue/insert', data),
+};

--- a/frontend/src/components/common/AdminSidebar.tsx
+++ b/frontend/src/components/common/AdminSidebar.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+const AdminSidebar: React.FC = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const getActiveMenu = () => {
+    if (location.pathname.includes('/admin/project')) return 'project';
+    if (location.pathname.includes('/admin/farm')) return 'farm';
+    if (location.pathname.includes('/admin/cultivation')) return 'cultivation';
+    if (location.pathname.includes('/admin/revenue')) return 'income';
+    if (location.pathname.includes('/admin/expense')) return 'expense';
+    return '';
+  };
+
+  const activeMenu = getActiveMenu();
+
+  return (
+    <nav className="sidebar">
+      <div className="logo">
+        마이리틀 스마트팜
+        <br />
+        Admin
+      </div>
+      <a
+        href="#"
+        className={`menu-item ${activeMenu === 'project' ? 'active' : ''}`}
+        onClick={(e) => {
+          e.preventDefault();
+          navigate('/admin/project');
+        }}
+      >
+        프로젝트 등록/수정
+      </a>
+      <a
+        href="#"
+        className={`menu-item ${activeMenu === 'farm' ? 'active' : ''}`}
+        onClick={(e) => {
+          e.preventDefault();
+          navigate('/admin/farm');
+        }}
+      >
+        농장 등록/수정
+      </a>
+      <a
+        href="#"
+        className={`menu-item ${activeMenu === 'cultivation' ? 'active' : ''}`}
+        onClick={(e) => {
+          e.preventDefault();
+          navigate('/admin/cultivation');
+        }}
+      >
+        재배 정보 입력
+      </a>
+      <a
+        href="#"
+        className={`menu-item ${activeMenu === 'income' ? 'active' : ''}`}
+        onClick={(e) => {
+          e.preventDefault();
+          navigate('/admin/revenue');
+        }}
+      >
+        수익 정보 입력
+      </a>
+      <a
+        href="#"
+        className={`menu-item ${activeMenu === 'expense' ? 'active' : ''}`}
+        onClick={(e) => {
+          e.preventDefault();
+          navigate('/admin/expense');
+        }}
+      >
+        지출 정보 입력
+      </a>
+
+      <div className="sidebar-footer">
+        <a
+          href="#"
+          className="menu-item home-link"
+          onClick={(e) => {
+            e.preventDefault();
+            navigate('/');
+          }}
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"
+              stroke="rgba(255,255,255,0.7)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <polyline
+              points="9,22 9,12 15,12 15,22"
+              stroke="rgba(255,255,255,0.7)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <span>사용자 홈으로</span>
+        </a>
+      </div>
+    </nav>
+  );
+};
+
+export default AdminSidebar;

--- a/frontend/src/pages/admin/CultivationRegister.tsx
+++ b/frontend/src/pages/admin/CultivationRegister.tsx
@@ -1,0 +1,213 @@
+import React, { useState, useEffect } from 'react';
+import { adminApi } from '@/api/adminApi';
+import Button from '@/components/common/Button';
+import Toast from '@/components/common/Toast';
+import AdminSidebar from '@/components/common/AdminSidebar';
+import '../../styles/admin.css';
+
+interface CultivationData {
+  projectId: number;
+  managerCount: number;
+  crop: string;
+  expectedYield: number;
+  actualYield?: number;
+  plantingDate: string;
+  harvestDate?: string;
+  notes?: string;
+}
+
+interface Project {
+  projectId: number;
+  projectName: string;
+  projectRound: number;
+}
+
+const CultivationRegister: React.FC = () => {
+  const [formData, setFormData] = useState<CultivationData>({
+    projectId: 0,
+    managerCount: 0,
+    crop: '',
+    expectedYield: 0,
+    actualYield: 0,
+    plantingDate: '',
+    harvestDate: '',
+    notes: '',
+  });
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        const data = await adminApi.getProjects();
+        setProjects(data);
+      } catch (error) {
+        console.error('프로젝트 로드 실패:', error);
+      }
+    };
+    loadProjects();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await adminApi.insertCultivation(formData);
+      Toast.show('재배 정보 등록 완료');
+    } catch (error) {
+      Toast.show('등록 실패');
+    }
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
+  ) => {
+    const { name, value, type } = e.target;
+    const parsedValue =
+      type === 'number' ? (value === '' ? 0 : parseFloat(value)) : value;
+    setFormData({ ...formData, [name]: parsedValue });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <AdminSidebar />
+      <main className="flex-1 p-10">
+        <div className="max-w-5xl mx-auto">
+          <h1 className="text-3xl font-bold mb-8">재배 정보 등록</h1>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">연관 프로젝트 설정</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    대상 프로젝트 선택 (Project ID)
+                  </label>
+                  <select
+                    name="projectId"
+                    value={String(formData.projectId)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  >
+                    <option value="0">선택</option>
+                    {projects.map((project) => (
+                      <option key={project.projectId} value={project.projectId}>
+                        {project.projectName} ({project.projectRound}차)
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    현장 관리자 수 (Manager Count)
+                  </label>
+                  <input
+                    type="number"
+                    name="managerCount"
+                    value={formData.managerCount}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">작물 및 생산 정보</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    재배 작물 (Crop)
+                  </label>
+                  <input
+                    type="text"
+                    name="crop"
+                    value={formData.crop}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    예상 생산량
+                  </label>
+                  <input
+                    type="number"
+                    name="expectedYield"
+                    value={formData.expectedYield}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    실제 생산량
+                  </label>
+                  <input
+                    type="number"
+                    name="actualYield"
+                    value={formData.actualYield}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">재배 일정 및 결과</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    파종/식재 일자
+                  </label>
+                  <input
+                    type="date"
+                    name="plantingDate"
+                    value={formData.plantingDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    수확 일자
+                  </label>
+                  <input
+                    type="date"
+                    name="harvestDate"
+                    value={formData.harvestDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+                <div className="md:col-span-3">
+                  <label className="block text-sm font-medium mb-1">
+                    비고 <span className="text-gray-500">(선택)</span>
+                  </label>
+                  <textarea
+                    name="notes"
+                    value={formData.notes}
+                    onChange={handleInputChange}
+                    rows={3}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+              </div>
+            </div>
+            <Button
+              type="submit"
+              className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700"
+            >
+              재배 정보 저장하기
+            </Button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default CultivationRegister;

--- a/frontend/src/pages/admin/ExpenseRegister.tsx
+++ b/frontend/src/pages/admin/ExpenseRegister.tsx
@@ -1,0 +1,237 @@
+import React, { useState, useEffect } from 'react';
+import { adminApi } from '@/api/adminApi';
+import Button from '@/components/common/Button';
+import Toast from '@/components/common/Toast';
+import AdminSidebar from '@/components/common/AdminSidebar';
+import '../../styles/admin.css';
+
+interface ExpenseData {
+  projectId: number;
+  recordedBy: string;
+  category: string;
+  subCategory: string;
+  amount: number;
+  startDate: string;
+  endDate: string;
+  vendor: string;
+  description?: string;
+}
+
+interface Project {
+  projectId: number;
+  projectName: string;
+  projectRound: number;
+}
+
+const ExpenseRegister: React.FC = () => {
+  const [formData, setFormData] = useState<ExpenseData>({
+    projectId: 0,
+    recordedBy: 'admin', // 기본값
+    category: '',
+    subCategory: '',
+    amount: 0,
+    startDate: '',
+    endDate: '',
+    vendor: '',
+    description: '',
+  });
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        const data = await adminApi.getProjects();
+        setProjects(data);
+      } catch (error) {
+        console.error('프로젝트 로드 실패:', error);
+      }
+    };
+    loadProjects();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await adminApi.insertExpense(formData);
+      Toast.show('지출 데이터 기록 완료');
+    } catch (error) {
+      Toast.show('기록 실패');
+    }
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
+  ) => {
+    const { name, value, type } = e.target;
+    const parsedValue =
+      type === 'number' ? (value === '' ? 0 : parseFloat(value)) : value;
+    setFormData({ ...formData, [name]: parsedValue });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <AdminSidebar />
+      <main className="flex-1 p-10">
+        <div className="max-w-5xl mx-auto">
+          <h1 className="text-3xl font-bold mb-8">지출 정보 등록</h1>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">지출 발생 프로젝트</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    프로젝트 선택 (Project ID)
+                  </label>
+                  <select
+                    name="projectId"
+                    value={String(formData.projectId)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  >
+                    <option value="0">
+                      지출이 발생한 프로젝트를 선택하세요
+                    </option>
+                    {projects.map((project) => (
+                      <option key={project.projectId} value={project.projectId}>
+                        {project.projectName} ({project.projectRound}차)
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    기록자 (Recorded By)
+                  </label>
+                  <input
+                    type="text"
+                    name="recordedBy"
+                    value={formData.recordedBy}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded bg-gray-100"
+                    readOnly
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">지출 상세 정보</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    지출 카테고리
+                  </label>
+                  <select
+                    name="category"
+                    value={formData.category}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  >
+                    <option value="">대분류 선택</option>
+                    <option value="인건비">인건비</option>
+                    <option value="재료비">재료비</option>
+                    <option value="설비비">설비비</option>
+                    <option value="유지보수비">유지보수비</option>
+                    <option value="기타">기타</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    세부 항목 (Sub Category)
+                  </label>
+                  <input
+                    type="text"
+                    name="subCategory"
+                    value={formData.subCategory}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    placeholder="예: 전기료, 종자구입비"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    지출 금액 (Amount)
+                  </label>
+                  <input
+                    type="number"
+                    name="amount"
+                    value={formData.amount}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    placeholder="단위: KRW"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    지출 시작일
+                  </label>
+                  <input
+                    type="date"
+                    name="startDate"
+                    value={formData.startDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    지출 종료일
+                  </label>
+                  <input
+                    type="date"
+                    name="endDate"
+                    value={formData.endDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    결제처/거래처 (Vendor)
+                  </label>
+                  <input
+                    type="text"
+                    name="vendor"
+                    value={formData.vendor}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    placeholder="예: 한국전력, OO종묘"
+                    required
+                  />
+                </div>
+                <div className="md:col-span-3">
+                  <label className="block text-sm font-medium mb-1">
+                    지출 상세 설명 <span className="text-gray-500">(선택)</span>
+                  </label>
+                  <textarea
+                    name="description"
+                    value={formData.description}
+                    onChange={handleInputChange}
+                    rows={3}
+                    className="w-full p-2 border rounded"
+                    placeholder="지출 증빙 번호나 구체적인 사유를 입력하세요."
+                  />
+                </div>
+              </div>
+            </div>
+            <Button
+              type="submit"
+              className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700"
+            >
+              지출 데이터 기록 완료
+            </Button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default ExpenseRegister;

--- a/frontend/src/pages/admin/FarmRegister.tsx
+++ b/frontend/src/pages/admin/FarmRegister.tsx
@@ -1,0 +1,324 @@
+import React, { useState, useEffect } from 'react';
+import { adminApi } from '@/api/adminApi';
+import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import Toast from '@/components/common/Toast';
+import AdminSidebar from '@/components/common/AdminSidebar';
+import '../../styles/admin.css';
+
+interface FarmData {
+  farmName: string;
+  farmType: string;
+  area: number;
+  openAt: string;
+  addressSido: string;
+  addressSigungu: string;
+  addressStreet: string;
+  latitude: number;
+  longitude: number;
+  altitude: number;
+  description?: string;
+}
+
+declare global {
+  interface Window {
+    daum: any;
+  }
+}
+
+const FarmRegister: React.FC = () => {
+  const [formData, setFormData] = useState<FarmData>({
+    farmName: '',
+    farmType: '',
+    area: 0,
+    openAt: '',
+    addressSido: '',
+    addressSigungu: '',
+    addressStreet: '',
+    latitude: 0,
+    longitude: 0,
+    altitude: 0,
+    description: '',
+  });
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    // daum Postcode 스크립트 로드
+    const script = document.createElement('script');
+    script.src =
+      '//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js';
+    script.async = true;
+    document.head.appendChild(script);
+
+    return () => {
+      document.head.removeChild(script);
+    };
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const response = await adminApi.insertFarm(formData);
+      if (response === 'success') {
+        Toast.show('농장 등록이 완료되었습니다!');
+        // 리다이렉트 로직 추가 가능
+      } else {
+        Toast.show('등록 실패: ' + response);
+      }
+    } catch (error) {
+      console.error(error);
+      Toast.show('등록 실패');
+    }
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
+  ) => {
+    const { name, value, type } = e.target;
+    const parsedValue =
+      type === 'number' ? (value === '' ? 0 : parseFloat(value)) : value;
+    setFormData({ ...formData, [name]: parsedValue });
+  };
+
+  const searchAddress = () => {
+    new window.daum.Postcode({
+      oncomplete: function (data: any) {
+        setFormData({
+          ...formData,
+          addressSido: data.sido,
+          addressSigungu: data.sigungu,
+          addressStreet: data.roadAddress,
+        });
+        fetchCoordsFromServer(data.roadAddress);
+      },
+    }).open();
+  };
+
+  const fetchCoordsFromServer = async (address: string) => {
+    try {
+      const coords = await adminApi.getCoords(address);
+      if (coords) {
+        setFormData({
+          ...formData,
+          latitude: coords.latitude,
+          longitude: coords.longitude,
+          altitude: coords.altitude || 0,
+        });
+        Toast.show('위치 좌표가 자동으로 설정되었습니다.');
+      }
+    } catch (error) {
+      console.error('좌표 로드 실패:', error);
+      Toast.show('좌표를 가져오지 못했습니다. 수동 입력을 권장합니다.');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <AdminSidebar />
+      <main className="flex-1 p-10">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex justify-between items-center mb-8">
+            <h1 className="text-3xl font-bold">농장 등록/수정</h1>
+            <Button
+              onClick={() => setIsModalOpen(false)}
+              className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+            >
+              농장 정보 불러오기
+            </Button>
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* 기본 정보 */}
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">기본 정보</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    농장 명칭
+                  </label>
+                  <input
+                    type="text"
+                    name="farmName"
+                    value={formData.farmName}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    placeholder="예: 청라 토마토 1호 농장"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    농장 유형
+                  </label>
+                  <select
+                    name="farmType"
+                    value={formData.farmType}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  >
+                    <option value="">선택</option>
+                    <option value="토마토">토마토</option>
+                    <option value="오이">오이</option>
+                    <option value="상추">상추</option>
+                    <option value="딸기">딸기</option>
+                    <option value="기타">기타</option>
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    재배 면적 (㎡)
+                  </label>
+                  <input
+                    type="number"
+                    step="0.01"
+                    name="area"
+                    value={formData.area}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    placeholder="0.00"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    개설 일자
+                  </label>
+                  <input
+                    type="date"
+                    name="openAt"
+                    value={formData.openAt}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <label className="block text-sm font-medium mb-1">
+                    농장 소개 <span className="text-gray-500">(선택)</span>
+                  </label>
+                  <textarea
+                    name="description"
+                    value={formData.description}
+                    onChange={handleInputChange}
+                    rows={3}
+                    className="w-full p-2 border rounded"
+                    placeholder="농장의 특징 및 시설 정보를 입력하세요."
+                  />
+                </div>
+              </div>
+            </div>
+            {/* 위치 정보 */}
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">위치 정보</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    시/도
+                  </label>
+                  <input
+                    type="text"
+                    name="addressSido"
+                    value={formData.addressSido}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    시/군/구
+                  </label>
+                  <input
+                    type="text"
+                    name="addressSigungu"
+                    value={formData.addressSigungu}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    도로명 주소
+                  </label>
+                  <input
+                    type="text"
+                    name="addressStreet"
+                    value={formData.addressStreet}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    상세 주소
+                  </label>
+                  <input
+                    type="text"
+                    name="detailedAddress"
+                    className="w-full p-2 border rounded"
+                    placeholder="상세 주소"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">위도</label>
+                  <input
+                    type="number"
+                    step="any"
+                    name="latitude"
+                    value={formData.latitude}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">경도</label>
+                  <input
+                    type="number"
+                    step="any"
+                    name="longitude"
+                    value={formData.longitude}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">고도</label>
+                  <input
+                    type="number"
+                    step="any"
+                    name="altitude"
+                    value={formData.altitude}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+                <div className="flex items-end">
+                  <Button
+                    onClick={searchAddress}
+                    className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+                  >
+                    주소 검색
+                  </Button>
+                </div>
+              </div>
+            </div>
+            <Button
+              type="submit"
+              className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700"
+            >
+              농장 등록 완료
+            </Button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default FarmRegister;

--- a/frontend/src/pages/admin/ProjectRegister.tsx
+++ b/frontend/src/pages/admin/ProjectRegister.tsx
@@ -1,0 +1,954 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { adminApi } from '@/api/adminApi';
+import Button from '@/components/common/Button';
+import AdminSidebar from '@/components/common/AdminSidebar';
+import '../../styles/admin.css';
+
+interface ProjectFormData {
+  projectId: number;
+  farmId: number;
+  projectName: string;
+  projectRound: number;
+  projectDescription: string;
+  tokenName: string;
+  tokenSymbol: string;
+  tickerSymbol: string;
+  targetAmount: number;
+  totalSupply: number;
+  minAmountPerInvestor: number;
+  maxAmountPerInvestor: number;
+  actualAmount: number;
+  expectedReturn: number;
+  roi: number;
+  managerCount: number;
+  announcementStartDate: string;
+  announcementEndDate: string;
+  subscriptionStartDate: string;
+  subscriptionEndDate: string;
+  resultAnnouncementDate: string;
+  projectStartDate: string;
+  projectEndDate: string;
+  images: string[];
+  subscriptionRate: number;
+  projectStatus:
+    | 'ANNOUNCEMENT'
+    | 'SUBSCRIPTION'
+    | 'INPROGRESS'
+    | 'CANCELED'
+    | 'COMPLETED';
+  method: string;
+  crop?: string;
+  temperatureInside: number[];
+  humidityInside: number[];
+
+  farm: {
+    addressSido: string;
+    area: number;
+  };
+  projectImages?: File[];
+  deletedPictureIds?: number[];
+}
+
+interface AdminProject {
+  projectId: number;
+  projectName: string;
+  projectRound: number;
+  farmId: number;
+  targetAmount: number;
+  minAmountPerInvestor: number;
+  maxAmountPerInvestor?: number;
+  actualAmount?: number;
+  expectedReturn: number;
+  roi?: number;
+  managerCount: number;
+  announcementStartDate: string;
+  announcementEndDate: string;
+  subscriptionStartDate: string;
+  subscriptionEndDate: string;
+  resultAnnouncementDate: string;
+  projectStartDate: string;
+  projectEndDate: string;
+  tokenName?: string;
+  tokenSymbol?: string;
+  tickerSymbol?: string;
+  totalSupply?: number;
+}
+interface Farm {
+  farmId: number;
+  farmName: string;
+}
+
+type Project = {
+  projectId: number;
+  projectName: string;
+  projectRound: number;
+  farmId: number;
+  targetAmount: number;
+  minAmountPerInvestor: number;
+  maxAmountPerInvestor?: number;
+  actualAmount?: number;
+  expectedReturn: number;
+  roi?: number;
+  managerCount: number;
+  announcementStartDate: string;
+  announcementEndDate: string;
+  subscriptionStartDate: string;
+  subscriptionEndDate: string;
+  resultAnnouncementDate: string;
+  projectStartDate: string;
+  projectEndDate: string;
+  tokenName?: string;
+  tokenSymbol?: string;
+  totalSupply?: number;
+};
+
+const ProjectRegister: React.FC = () => {
+  const [formData, setFormData] = useState<ProjectFormData>({
+    projectId: 0,
+    farmId: 0,
+    projectName: '',
+    projectRound: 1,
+    projectDescription: '',
+    tokenName: '',
+    tokenSymbol: '',
+    tickerSymbol: '',
+    targetAmount: 0,
+    totalSupply: 0,
+    minAmountPerInvestor: 0,
+    maxAmountPerInvestor: 0,
+    actualAmount: 0,
+    expectedReturn: 0,
+    roi: 0,
+    managerCount: 0,
+    announcementStartDate: '',
+    announcementEndDate: '',
+    subscriptionStartDate: '',
+    subscriptionEndDate: '',
+    resultAnnouncementDate: '',
+    projectStartDate: '',
+    projectEndDate: '',
+    images: [],
+    subscriptionRate: 0,
+    projectStatus: 'ANNOUNCEMENT',
+    method: '',
+    crop: '',
+    temperatureInside: [],
+    humidityInside: [],
+    farm: {
+      addressSido: '',
+      area: 0,
+    },
+    projectImages: [],
+    deletedPictureIds: [],
+  });
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
+    null,
+  );
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [projects, setProjects] = useState<AdminProject[]>([]);
+  const [farms, setFarms] = useState<Farm[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        const result = await adminApi.getProjects();
+        setProjects(Array.isArray(result) ? result : (result?.data ?? []));
+      } catch (error) {
+        console.error('프로젝트 로드 실패:', error);
+        setProjects([]);
+      }
+    };
+    const loadFarms = async () => {
+      try {
+        const result = await adminApi.getFarms();
+        setFarms(Array.isArray(result) ? result : (result?.data ?? []));
+      } catch (error) {
+        console.error('농장 로드 실패:', error);
+        setFarms([]);
+      }
+    };
+    loadProjects();
+    loadFarms();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const form = new FormData();
+
+    // 필수 필드 추가
+    form.append('farmId', String(formData.farmId));
+    form.append('projectName', formData.projectName);
+    form.append('projectRound', String(formData.projectRound));
+    form.append('projectDescription', formData.projectDescription);
+    form.append('targetAmount', String(formData.targetAmount));
+    form.append('minAmountPerInvestor', String(formData.minAmountPerInvestor));
+    form.append('expectedReturn', String(formData.expectedReturn));
+    form.append('managerCount', String(formData.managerCount));
+    form.append(
+      'announcementStartDate',
+      toBackendDateTime(formData.announcementStartDate),
+    );
+    form.append(
+      'announcementEndDate',
+      toBackendDateTime(formData.announcementEndDate),
+    );
+    form.append(
+      'subscriptionStartDate',
+      toBackendDateTime(formData.subscriptionStartDate),
+    );
+    form.append(
+      'subscriptionEndDate',
+      toBackendDateTime(formData.subscriptionEndDate),
+    );
+    form.append(
+      'resultAnnouncementDate',
+      toBackendDateTime(formData.resultAnnouncementDate),
+    );
+    form.append(
+      'projectStartDate',
+      toBackendDateTime(formData.projectStartDate),
+    );
+    form.append('projectEndDate', toBackendDateTime(formData.projectEndDate));
+
+    // 선택적 필드
+    form.append('tokenName', formData.tokenName);
+    form.append('tickerSymbol', formData.tickerSymbol || '');
+    form.append('totalSupply', String(formData.totalSupply || 0));
+    form.append(
+      'maxAmountPerInvestor',
+      String(formData.maxAmountPerInvestor || 0),
+    );
+    form.append('actualAmount', String(formData.actualAmount || 0));
+
+    // 이미지 파일 추가
+    if (formData.projectImages && formData.projectImages.length > 0) {
+      formData.projectImages.forEach((file, index) => {
+        form.append(`projectImages`, file);
+      });
+    }
+
+    try {
+      await adminApi.insertProject(form);
+      console.log('프로젝트 등록 완료');
+      alert('프로젝트가 등록되었습니다!');
+    } catch (error) {
+      console.log('등록 실패:', error);
+      alert('프로젝트 등록 중 오류가 발생했습니다.');
+    }
+  };
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const form = new FormData();
+
+    // 필수 필드 추가
+    form.append('projectId', String(formData.projectId));
+    form.append('farmId', String(formData.farmId));
+    form.append('projectName', formData.projectName);
+    form.append('projectRound', String(formData.projectRound));
+    form.append('projectDescription', formData.projectDescription);
+    form.append('targetAmount', String(formData.targetAmount));
+    form.append('minAmountPerInvestor', String(formData.minAmountPerInvestor));
+    form.append('expectedReturn', String(formData.expectedReturn));
+    form.append('managerCount', String(formData.managerCount));
+    form.append(
+      'announcementStartDate',
+      toBackendDateTime(formData.announcementStartDate),
+    );
+    form.append(
+      'announcementEndDate',
+      toBackendDateTime(formData.announcementEndDate),
+    );
+    form.append(
+      'subscriptionStartDate',
+      toBackendDateTime(formData.subscriptionStartDate),
+    );
+    form.append(
+      'subscriptionEndDate',
+      toBackendDateTime(formData.subscriptionEndDate),
+    );
+    form.append(
+      'resultAnnouncementDate',
+      toBackendDateTime(formData.resultAnnouncementDate),
+    );
+    form.append(
+      'projectStartDate',
+      toBackendDateTime(formData.projectStartDate),
+    );
+    form.append('projectEndDate', toBackendDateTime(formData.projectEndDate));
+
+    // 선택적 필드
+    form.append('tokenName', formData.tokenName);
+    form.append('tickerSymbol', formData.tickerSymbol || '');
+    form.append('totalSupply', String(formData.totalSupply || 0));
+    form.append(
+      'maxAmountPerInvestor',
+      String(formData.maxAmountPerInvestor || 0),
+    );
+    form.append('actualAmount', String(formData.actualAmount || 0));
+
+    // 이미지 파일 추가
+    if (formData.projectImages && formData.projectImages.length > 0) {
+      formData.projectImages.forEach((file, index) => {
+        form.append(`projectImages`, file);
+      });
+    }
+
+    // 삭제된 이미지 ID
+    if (formData.deletedPictureIds && formData.deletedPictureIds.length > 0) {
+      form.append(
+        'deletedPictureIds',
+        JSON.stringify(formData.deletedPictureIds),
+      );
+    }
+
+    try {
+      await adminApi.updateProject(form);
+      console.log('프로젝트 수정 완료');
+      alert('프로젝트가 수정되었습니다!');
+    } catch (error) {
+      console.log('수정 실패:', error);
+      alert('프로젝트 수정 중 오류가 발생했습니다.');
+    }
+  };
+
+  const formatNumberInput = (value: any) => {
+    if (typeof value !== 'number') return value;
+    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  const parseNumberInput = (value: any) => {
+    if (typeof value === 'string') {
+      return parseFloat(value.replace(/,/g, '')) || 0;
+    }
+    return value || 0;
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
+  ) => {
+    const { name, value, type } = e.target;
+    const parsedValue = type === 'number' ? parseNumberInput(value) : value;
+    setFormData({ ...formData, [name]: parsedValue });
+  };
+
+  const renderNumberValue = (value: any) => {
+    if (!value) return '';
+    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  const toInputDateTime = (dateString?: string | null) => {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    const tzOffset = date.getTimezoneOffset() * 60000;
+    return new Date(date.getTime() - tzOffset).toISOString().slice(0, 16);
+  };
+
+  const toBackendDateTime = (dateString: string): string => {
+    if (!dateString) return '';
+    // dateString 형식: "2026-04-02T09:00"
+    // 타임존 오프셋 계산 (한국: +09:00)
+    const offset = new Date().getTimezoneOffset();
+    const hours = String(Math.abs(Math.floor(offset / 60))).padStart(2, '0');
+    const minutes = String(Math.abs(offset % 60)).padStart(2, '0');
+    const sign = offset <= 0 ? '+' : '-';
+    const tzString = `${sign}${hours}:${minutes}`;
+    // 초 추가: "2026-04-02T09:00:00+09:00"
+    return `${dateString}:00${tzString}`;
+  };
+
+  const openModal = async () => {
+    setIsModalOpen(true);
+    setLoading(true);
+    try {
+      const result = await adminApi.getProjects();
+      setProjects(Array.isArray(result) ? result : (result?.data ?? []));
+    } catch (error) {
+      console.error('프로젝트 로드 실패:', error);
+      setProjects([]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const selectProject = async (project: AdminProject) => {
+    setLoading(true);
+    try {
+      const detail = await adminApi.getProjectDetails(project.projectId);
+      const selected = detail as any;
+
+      // 토큰 정보 별도로 불러오기
+      let tokenInfo: any = null;
+      try {
+        const tokenResult = await adminApi.getTokens(project.projectId);
+        console.log('📦 토큰 정보 응답:', tokenResult);
+        tokenInfo = tokenResult as any;
+      } catch (e) {
+        console.log('❌ 토큰 정보 로드 실패:', e);
+      }
+
+      console.log('📋 프로젝트 상세 정보:', selected);
+      console.log('🎫 토큰 정보:', tokenInfo);
+      console.log(
+        '선택 우선순위 - tokenName:',
+        tokenInfo?.tokenName || selected.tokenName,
+      );
+      console.log(
+        '선택 우선순위 - tickerSymbol:',
+        tokenInfo?.tickerSymbol || selected.tickerSymbol,
+      );
+
+      setSelectedProjectId(project.projectId);
+      setFormData({
+        ...formData,
+        projectId: selected.projectId ?? project.projectId,
+        farmId: selected.farmId ?? project.farmId,
+        projectName: selected.projectName ?? project.projectName,
+        projectRound: selected.projectRound ?? project.projectRound,
+        projectDescription: selected.projectDescription ?? '',
+        tokenName:
+          tokenInfo?.tokenName || selected.tokenName || formData.tokenName,
+        tokenSymbol:
+          tokenInfo?.tickerSymbol ||
+          selected.tickerSymbol ||
+          project.tickerSymbol ||
+          '',
+        tickerSymbol:
+          tokenInfo?.tickerSymbol ||
+          selected.tickerSymbol ||
+          project.tickerSymbol ||
+          '',
+        targetAmount: Number(
+          selected.targetAmount ?? project.targetAmount ?? 0,
+        ),
+        totalSupply: Number(
+          tokenInfo?.totalSupply ??
+            selected.totalSupply ??
+            project.totalSupply ??
+            0,
+        ),
+        minAmountPerInvestor: Number(
+          selected.minAmountPerInvestor ?? project.minAmountPerInvestor ?? 0,
+        ),
+        maxAmountPerInvestor: Number(
+          selected.maxAmountPerInvestor ?? project.maxAmountPerInvestor ?? 0,
+        ),
+        actualAmount: Number(
+          selected.actualAmount ?? project.actualAmount ?? 0,
+        ),
+        subscriptionRate: Number(
+          selected.subscriptionRate ?? formData.subscriptionRate ?? 0,
+        ),
+        projectStatus: (selected.projectStatus ??
+          formData.projectStatus) as ProjectFormData['projectStatus'],
+        announcementStartDate: toInputDateTime(selected.announcementStartDate),
+        announcementEndDate: toInputDateTime(selected.announcementEndDate),
+        subscriptionStartDate: toInputDateTime(selected.subscriptionStartDate),
+        subscriptionEndDate: toInputDateTime(selected.subscriptionEndDate),
+        resultAnnouncementDate: toInputDateTime(
+          selected.resultAnnouncementDate,
+        ),
+        projectStartDate: toInputDateTime(selected.projectStartDate),
+        projectEndDate: toInputDateTime(selected.projectEndDate),
+        expectedReturn: Number(
+          selected.expectedReturn ?? project.expectedReturn ?? 0,
+        ),
+        roi: Number(selected.roi ?? selected.expectedReturn ?? 0),
+        managerCount: Number(
+          selected.managerCount ?? project.managerCount ?? 0,
+        ),
+        method: selected.method || '',
+        crop: selected.crop || '',
+        temperatureInside: Array.isArray(selected.temperatureInside)
+          ? selected.temperatureInside.map((value: any) => Number(value))
+          : [],
+        humidityInside: Array.isArray(selected.humidityInside)
+          ? selected.humidityInside.map((value: any) => Number(value))
+          : [],
+        images: Array.isArray(selected.images) ? selected.images : [],
+        farm: {
+          addressSido: selected.farm?.addressSido || formData.farm.addressSido,
+          area: Number(selected.farm?.area ?? formData.farm.area ?? 0),
+        },
+      });
+      setImagePreviews(Array.isArray(selected.images) ? selected.images : []);
+    } catch (error) {
+      console.error('프로젝트 상세 로드 실패:', error);
+    } finally {
+      setLoading(false);
+      setIsModalOpen(false);
+    }
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (files) {
+      const newPreviews = Array.from(files).map((file) =>
+        URL.createObjectURL(file),
+      );
+      setImagePreviews([...imagePreviews, ...newPreviews]);
+      setFormData({
+        ...formData,
+        projectImages: [
+          ...(formData.projectImages || []),
+          ...Array.from(files),
+        ],
+      });
+    }
+  };
+
+  const removeImage = (index: number) => {
+    const newPreviews = imagePreviews.filter((_, i) => i !== index);
+    setImagePreviews(newPreviews);
+    const newImages = formData.projectImages?.filter((_, i) => i !== index);
+    setFormData({ ...formData, projectImages: newImages });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <AdminSidebar />
+      <main className="flex-1 p-10">
+        <div className="max-w-5xl mx-auto">
+          <div className="flex justify-between items-center mb-8">
+            <h1 className="text-3xl font-bold">프로젝트 등록/수정</h1>
+            <Button
+              onClick={openModal}
+              className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+            >
+              프로젝트 정보 불러오기
+            </Button>
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            {/* 기본 정보 */}
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">기본 정보</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    농장 선택 (Farm ID)
+                  </label>
+                  <select
+                    name="farmId"
+                    value={String(formData.farmId)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  >
+                    <option value="0">선택</option>
+                    {farms.map((farm) => (
+                      <option key={farm.farmId} value={farm.farmId}>
+                        {farm.farmName}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    프로젝트 명
+                  </label>
+                  <input
+                    type="text"
+                    name="projectName"
+                    value={formData.projectName}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    프로젝트 차수 (Round)
+                  </label>
+                  <input
+                    type="number"
+                    name="projectRound"
+                    value={formData.projectRound}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div className="md:col-span-3">
+                  <label className="block text-sm font-medium mb-1">
+                    프로젝트 상세 설명{' '}
+                    <span className="text-gray-500">(선택)</span>
+                  </label>
+                  <textarea
+                    name="projectDescription"
+                    value={formData.projectDescription}
+                    onChange={handleInputChange}
+                    rows={3}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+              </div>
+            </div>
+            {/* 투자 설정 */}
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">투자 설정</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    토큰 명칭
+                  </label>
+                  <input
+                    type="text"
+                    name="tokenName"
+                    value={formData.tokenName}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    종목 코드 (Ticker)
+                  </label>
+                  <input
+                    type="text"
+                    name="tickerSymbol"
+                    value={formData.tickerSymbol}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    목표 금액
+                  </label>
+                  <input
+                    type="text"
+                    name="targetAmount"
+                    value={renderNumberValue(formData.targetAmount)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    토큰 총 발행량
+                  </label>
+                  <input
+                    type="text"
+                    name="totalSupply"
+                    value={renderNumberValue(formData.totalSupply)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    1인당 최소 투자금
+                  </label>
+                  <input
+                    type="text"
+                    name="minAmountPerInvestor"
+                    value={renderNumberValue(formData.minAmountPerInvestor)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    현재 모집 금액 <span className="text-gray-500">(선택)</span>
+                  </label>
+                  <input
+                    type="text"
+                    name="actualAmount"
+                    value={renderNumberValue(formData.actualAmount)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    청약률
+                  </label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    name="subscriptionRate"
+                    value={formData.subscriptionRate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+              </div>
+            </div>
+            {/* 일정 및 기타 */}
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">일정 및 기타</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    공고 시작일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="announcementStartDate"
+                    value={formData.announcementStartDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    공고 종료일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="announcementEndDate"
+                    value={formData.announcementEndDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    청약 시작일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="subscriptionStartDate"
+                    value={formData.subscriptionStartDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    청약 종료일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="subscriptionEndDate"
+                    value={formData.subscriptionEndDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    결과 발표일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="resultAnnouncementDate"
+                    value={formData.resultAnnouncementDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    1인당 최대 투자금
+                  </label>
+                  <input
+                    type="text"
+                    name="maxAmountPerInvestor"
+                    value={renderNumberValue(formData.maxAmountPerInvestor)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    예상 수익률 (ROI) %
+                  </label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    name="expectedReturn"
+                    value={formData.expectedReturn}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    사업 시작일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="projectStartDate"
+                    value={formData.projectStartDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    사업 종료일
+                  </label>
+                  <input
+                    type="datetime-local"
+                    name="projectEndDate"
+                    value={formData.projectEndDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    현장 관리자 수
+                  </label>
+                  <input
+                    type="number"
+                    name="managerCount"
+                    value={formData.managerCount}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    재배 방식
+                  </label>
+                  <input
+                    type="text"
+                    name="method"
+                    value={formData.method}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    작물 종류
+                  </label>
+                  <input
+                    type="text"
+                    name="crop"
+                    value={formData.crop || ''}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                  />
+                </div>
+              </div>
+            </div>
+            {/* 프로젝트 이미지 */}
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">
+                프로젝트 이미지 등록
+              </h2>
+              <div className="flex flex-wrap gap-4">
+                {imagePreviews.map((src, index) => (
+                  <div key={index} className="relative">
+                    <img
+                      src={src}
+                      alt="preview"
+                      className="w-24 h-24 object-cover rounded"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeImage(index)}
+                      className="absolute top-0 right-0 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center"
+                    >
+                      ×
+                    </button>
+                  </div>
+                ))}
+                <div
+                  className="w-24 h-24 border-2 border-dashed border-gray-300 rounded flex items-center justify-center cursor-pointer"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <span className="text-2xl text-gray-400">+</span>
+                </div>
+              </div>
+              <input
+                type="file"
+                ref={fileInputRef}
+                onChange={handleImageChange}
+                multiple
+                className="hidden"
+              />
+            </div>
+            <div className="flex gap-4 pt-6 border-t">
+              <Button
+                type="submit"
+                onClick={handleSubmit}
+                className="bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 font-bold text-lg flex-1"
+              >
+                프로젝트 등록
+              </Button>
+              <Button
+                type="button"
+                onClick={handleUpdate}
+                className="bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 font-bold text-lg flex-1"
+              >
+                프로젝트 수정
+              </Button>
+            </div>
+          </form>
+        </div>
+        {isModalOpen && (
+          <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
+            <div className="bg-white rounded-lg p-6 max-w-2xl w-full max-h-96 flex flex-col shadow-2xl">
+              <div className="flex justify-between items-center mb-4">
+                <h3 className="text-xl font-bold text-gray-800">
+                  지난 프로젝트 목록 선택
+                </h3>
+                <button
+                  onClick={() => setIsModalOpen(false)}
+                  className="text-gray-400 hover:text-gray-700 text-2xl font-bold"
+                >
+                  ×
+                </button>
+              </div>
+
+              {loading ? (
+                <div className="text-center py-8">
+                  <div className="text-gray-600">로딩 중...</div>
+                </div>
+              ) : projects.length === 0 ? (
+                <div className="text-center py-8">
+                  <div className="text-gray-500">프로젝트 목록이 없습니다.</div>
+                </div>
+              ) : (
+                <ul className="space-y-2 overflow-y-auto flex-1 border rounded-lg p-2">
+                  {projects.map((project) => (
+                    <li
+                      key={project.projectId}
+                      className="p-3 border rounded cursor-pointer hover:bg-blue-50 hover:border-blue-300 transition"
+                      onClick={() => selectProject(project)}
+                    >
+                      <strong className="text-gray-800">
+                        {project.projectName} ({project.projectRound}차)
+                      </strong>
+                      <br />
+                      <small className="text-gray-600">
+                        ID: {project.projectId} | 목표액:{' '}
+                        {project.targetAmount?.toLocaleString?.() || 0}원 |
+                        예상수익: {project.expectedReturn}%
+                      </small>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default ProjectRegister;

--- a/frontend/src/pages/admin/RevenueRegister.tsx
+++ b/frontend/src/pages/admin/RevenueRegister.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from 'react';
+import { adminApi } from '@/api/adminApi';
+import Button from '@/components/common/Button';
+import Toast from '@/components/common/Toast';
+import AdminSidebar from '@/components/common/AdminSidebar';
+import '../../styles/admin.css';
+
+interface RevenueData {
+  projectId: number;
+  recordedBy: string;
+  startDate: string;
+  endDate: string;
+  amount: number;
+  description?: string;
+}
+
+interface Project {
+  projectId: number;
+  projectName: string;
+  projectRound: number;
+}
+
+const RevenueRegister: React.FC = () => {
+  const [formData, setFormData] = useState<RevenueData>({
+    projectId: 0,
+    recordedBy: 'admin', // 기본값
+    startDate: '',
+    endDate: '',
+    amount: 0,
+    description: '',
+  });
+  const [projects, setProjects] = useState<Project[]>([]);
+
+  useEffect(() => {
+    const loadProjects = async () => {
+      try {
+        const data = await adminApi.getProjects();
+        setProjects(data);
+      } catch (error) {
+        console.error('프로젝트 로드 실패:', error);
+      }
+    };
+    loadProjects();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await adminApi.insertRevenue(formData);
+      Toast.show('수익 데이터 기록 완료');
+    } catch (error) {
+      Toast.show('기록 실패');
+    }
+  };
+
+  const handleInputChange = (
+    e: React.ChangeEvent<
+      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
+    >,
+  ) => {
+    const { name, value, type } = e.target;
+    const parsedValue =
+      type === 'number' ? (value === '' ? 0 : parseFloat(value)) : value;
+    setFormData({ ...formData, [name]: parsedValue });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex">
+      <AdminSidebar />
+      <main className="flex-1 p-10">
+        <div className="max-w-5xl mx-auto">
+          <h1 className="text-3xl font-bold mb-8">수익 정보 등록</h1>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">수익 발생 프로젝트</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    프로젝트 선택 (Project ID)
+                  </label>
+                  <select
+                    name="projectId"
+                    value={String(formData.projectId)}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  >
+                    <option value={0}>
+                      수익이 발생한 프로젝트를 선택하세요
+                    </option>
+                    {projects.map((project) => (
+                      <option key={project.projectId} value={project.projectId}>
+                        {project.projectName} ({project.projectRound}차)
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    기록자 (Recorded By)
+                  </label>
+                  <input
+                    type="text"
+                    name="recordedBy"
+                    value={formData.recordedBy}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded bg-gray-100"
+                    readOnly
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="bg-white rounded-lg p-6 shadow">
+              <h2 className="text-xl font-semibold mb-4">수익 상세 내용</h2>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    수익 발생 시작일
+                  </label>
+                  <input
+                    type="date"
+                    name="startDate"
+                    value={formData.startDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    수익 발생 종료일
+                  </label>
+                  <input
+                    type="date"
+                    name="endDate"
+                    value={formData.endDate}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    required
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium mb-1">
+                    수익 금액 (Amount)
+                  </label>
+                  <input
+                    type="number"
+                    name="amount"
+                    value={formData.amount}
+                    onChange={handleInputChange}
+                    className="w-full p-2 border rounded"
+                    placeholder="단위: KRW"
+                    required
+                  />
+                </div>
+                <div className="md:col-span-3">
+                  <label className="block text-sm font-medium mb-1">
+                    수익 내용 설명 <span className="text-gray-500">(선택)</span>
+                  </label>
+                  <textarea
+                    name="description"
+                    value={formData.description}
+                    onChange={handleInputChange}
+                    rows={4}
+                    className="w-full p-2 border rounded"
+                    placeholder="예: 2026년 1분기 토마토 판매 대금 및 탄소배출권 매각 수익"
+                  />
+                </div>
+              </div>
+            </div>
+            <Button
+              type="submit"
+              className="bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700"
+            >
+              수익 데이터 기록 완료
+            </Button>
+          </form>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default RevenueRegister;

--- a/frontend/src/pages/admin/index.ts
+++ b/frontend/src/pages/admin/index.ts
@@ -1,0 +1,5 @@
+export { default as FarmRegister } from './FarmRegister';
+export { default as ProjectRegister } from './ProjectRegister';
+export { default as CultivationRegister } from './CultivationRegister';
+export { default as ExpenseRegister } from './ExpenseRegister';
+export { default as RevenueRegister } from './RevenueRegister';

--- a/frontend/src/styles/admin.css
+++ b/frontend/src/styles/admin.css
@@ -1,0 +1,268 @@
+@charset "UTF-8";
+
+:root {
+  --green-600: #4a9f2e;
+  --green-700: #3f8f2d;
+  --gray-900: #191919;
+  --gray-600: #404040;
+  --gray-300: #c6c6c6;
+  --gray-50: #f8fafb;
+  --gray-0: #fcfcfc;
+  --header-height: 72px;
+  --sidebar-width: 240px;
+}
+
+body {
+  font-family: 'Pretendard', sans-serif;
+  margin: 0;
+  display: flex;
+  background-color: var(--gray-50);
+  color: var(--gray-600);
+  letter-spacing: -0.02em;
+}
+
+/* Side Navigation */
+.sidebar {
+  width: var(--sidebar-width);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--gray-900);
+  color: white;
+  position: fixed;
+  padding: 24px 0;
+}
+
+.sidebar .logo {
+  padding: 0 24px 32px;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--green-600);
+}
+
+.menu-item {
+  padding: 14px 24px;
+  cursor: pointer;
+  display: block;
+  text-decoration: none;
+  color: var(--gray-300);
+  font-size: 15px;
+  transition: 0.2s;
+}
+
+.menu-item:hover,
+.menu-item.active {
+  background: rgba(74, 159, 46, 0.1);
+  color: var(--green-600);
+  border-right: 4px solid var(--green-600);
+}
+
+.sidebar-footer {
+  margin-top: auto; /* 핵심: 남은 공간을 다 채워서 푸터를 아래로 보냄 */
+  padding: 20px 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.1); /* 구분선 */
+}
+
+.home-link {
+  display: flex !important;
+  align-items: center;
+  gap: 10px;
+  color: rgba(255, 255, 255, 0.8) !important;
+  font-size: 0.9rem;
+  transition: all 0.3s ease;
+}
+
+.home-link:hover {
+  background-color: var(--green-600) !important; /* 마우스 올리면 메인 컬러로 */
+  color: #fff !important;
+}
+
+.home-link i,
+.home-link svg {
+  opacity: 0.7;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid rgba(74, 159, 46, 0.1);
+  border-left-color: var(--green-600);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 10px;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Main Content */
+.main-content {
+  margin-left: var(--sidebar-width);
+  width: calc(100% - var(--sidebar-width));
+  padding: 40px;
+}
+
+.container-1200 {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.page-header h1 {
+  font-size: 32px;
+  color: var(--gray-900);
+  margin: 0;
+}
+
+.btn-load {
+  background: white;
+  border: 1px solid var(--green-600);
+  color: var(--green-600);
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: 0.2s;
+}
+
+.btn-load:hover {
+  background: var(--green-600);
+  color: white;
+}
+
+/* Form Style */
+.form-card {
+  background: var(--gray-0);
+  border-radius: 12px; /* Radius L */
+  padding: 32px;
+  margin-bottom: 24px;
+  /* Lines 144-145 omitted */
+}
+
+.section-title {
+  /* Lines 148-154 omitted */
+}
+
+.grid-3 {
+  /* Lines 157-160 omitted */
+}
+
+.grid-2 {
+  /* Lines 163-166 omitted */
+}
+
+.form-group {
+  /* Lines 169-173 omitted */
+}
+
+.full {
+  /* Lines 176-177 omitted */
+}
+
+label {
+  /* Lines 180-183 omitted */
+}
+
+.optional {
+  /* Lines 186-189 omitted */
+}
+
+input,
+select,
+textarea {
+  /* Lines 192-198 omitted */
+}
+
+input:focus {
+  /* Lines 201-202 omitted */
+}
+
+.button-group {
+  /* Lines 205-208 omitted */
+}
+
+.btn-submit {
+  /* Lines 211-221 omitted */
+}
+
+.btn-submit:hover {
+  /* Lines 224-225 omitted */
+}
+
+/* 사진 목록 */
+
+.image-preview-list {
+  /* Lines 230-233 omitted */
+}
+
+.image-upload-box {
+  /* Lines 236-249 omitted */
+}
+
+.image-upload-box:hover {
+  /* Lines 252-254 omitted */
+}
+
+.image-upload-box.add-btn .plus-icon {
+  /* Lines 257-259 omitted */
+}
+
+.image-upload-box img {
+  /* Lines 262-265 omitted */
+}
+
+/* 삭제 버튼 스타일 */
+.btn-remove {
+  /* Lines 269-283 omitted */
+}
+
+.image-upload-box:hover .btn-remove {
+  /* Lines 286-287 omitted */
+}
+
+/* Modal Style  */
+.modal {
+  /* Lines 291-299 omitted */
+}
+
+.modal-content {
+  /* Lines 302-307 omitted */
+}
+
+.modal-header {
+  /* Lines 310-315 omitted */
+}
+
+.project-list {
+  /* Lines 318-322 omitted */
+}
+
+.project-item {
+  /* Lines 325-328 omitted */
+}
+
+.project-item:hover {
+  /* Lines 331-332 omitted */
+}
+
+/* 읽기 전용 입력창 스타일 */
+.readonly-input {
+  /* Lines 336-340 omitted */
+}
+
+.input-with-btn {
+  /* Lines 343-345 omitted */
+}
+
+.btn-search {
+  /* Lines 348-356 omitted */
+}

--- a/frontend/src/types/projectType.ts
+++ b/frontend/src/types/projectType.ts
@@ -1,22 +1,35 @@
 interface ProjectData {
   projectId: number;
+  farmId: number;
   projectName: string;
-  images: string[];
-  expectedReturn: number;
-  subscriptionRate: number;
-  actualAmount: number;
+  projectRound: number;
+  projectDescription: string;
+  tokenName: string;
+  tickerSymbol: string;
   targetAmount: number;
   totalSupply: number;
   minAmountPerInvestor: number;
+  maxAmountPerInvestor: number;
+  actualAmount: number;
+  expectedReturn: number;
+  roi: number;
+  managerCount: number;
+  announcementStartDate: string;
+  announcementEndDate: string;
+  subscriptionStartDate: string;
+  subscriptionEndDate: string;
+  resultAnnouncementDate: string;
+  projectStartDate: string;
+  projectEndDate: string;
+  images: string[];
+  subscriptionRate: number;
   projectStatus:
     | 'ANNOUNCEMENT'
     | 'SUBSCRIPTION'
     | 'INPROGRESS'
     | 'CANCELED'
     | 'COMPLETED';
-  managerCount: number;
   method: string;
-  projectDescription: string;
   temperatureInside: number[];
   humidityInside: number[];
 
@@ -43,7 +56,7 @@ type ProjectDTO = {
   projectEndDate?: string | null;
 };
 
-type Project = {
+type AdminProject = {
   id: number;
   title: string;
   status: ProjectStatus;


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 관리자 페이지를 REACT로 변환하였습니다.
- 프로젝트 등록하는 기능만 추가하였습니다.

## 📝 변경 사항 (Key Changes)
- [ ] 
- [ ] 

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 관리자 페이지 | <img width="1695" height="901" alt="image" src="https://github.com/user-attachments/assets/cd116602-36c0-42cf-84d6-3558afba582a" /> |
| 프로젝트 정보 불러오기 | <img width="1676" height="858" alt="image" src="https://github.com/user-attachments/assets/ef72d3e9-e594-411a-9f5b-cb00cf8c5390" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x} 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
