### PR TITLE
[FEAT] 해시함수 SHA-256 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 
     // 8. Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    //9. 보안 알고리즘 (SHA-256) 라이브러리
+    implementation 'commons-codec:commons-codec:1.15'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/animalfarm/backend/global/HashManager.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/HashManager.java
@@ -2,12 +2,14 @@ package com.animalfarm.backend.global;
 
 import java.math.BigDecimal;
 
-import org.springframework.util.DigestUtils;
+import org.apache.commons.codec.digest.DigestUtils;
 
 public class HashManager {
 
 	public static String createHash(String prevHash, Long projectId, BigDecimal amount) {
-		return DigestUtils.md5DigestAsHex((prevHash + projectId + amount.toString()).getBytes());
+		long nonce = System.currentTimeMillis();
+		String rawData = prevHash + "|" + projectId + "|" + amount.toPlainString() + "|" + nonce;
+		return DigestUtils.sha256Hex(rawData);
 	}
 
 	public static String resolveHash(String hash) {


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 해시 함수 MD5에서 SHA256으로 변경하였습니다.
- HashManager에 nonce는 동일한 데이터가 발생했을 때 해시값이 같아지는 것을 방지하기 위해 추가하였습니다.

## 📝 변경 사항 (Key Changes)
- [ ] 해시함수 변경 MD5 -> SHA-256

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 변경된 해시함수 길이 | <img width="588" height="116" alt="image" src="https://github.com/user-attachments/assets/409776c5-7b0b-4920-86ce-d4e0c6a96e9a" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- gradle에 보안 알고리즘 (SHA-256) 라이브러리를 추가했습니다.

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
