### PR TITLE
[FEAT] 마이페이지 전자지갑 실시간 반영

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/domain/mypage/MypageService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/mypage/MypageService.java
@@ -238,7 +238,8 @@ public class MypageService {
 					userId,
 					walletId,
 					randomAccessToken,
-					randomRefreshToken);
+					randomRefreshToken
+				);
 				return walletId;
 			}
 		} catch (Exception e) {
@@ -278,7 +279,8 @@ public class MypageService {
 						userId,
 						walletId,
 						randomAccessToken,
-						randomRefreshToken);
+						randomRefreshToken
+					);
 					return walletId;
 				}
 			} catch (Exception e) {

--- a/backend/src/main/java/com/animalfarm/backend/domain/mypage/MypageService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/mypage/MypageService.java
@@ -30,6 +30,8 @@ import com.animalfarm.backend.domain.mypage.dto.TokenInfoDTO;
 import com.animalfarm.backend.domain.mypage.dto.UserInfoDTO;
 import com.animalfarm.backend.global.dto.ExternalApiResponseDTO;
 import com.animalfarm.backend.global.dto.PagedResponseDTO;
+import com.animalfarm.backend.global.exception.BusinessException;
+import com.animalfarm.backend.global.exception.ErrorCode;
 import com.animalfarm.backend.global.http.ExternalApiClient;
 import com.animalfarm.backend.global.security.SecurityUtil;
 
@@ -252,42 +254,47 @@ public class MypageService {
 	@Transactional
 	public Long craeteLinkAccount() {
 		Long userId = SecurityUtil.getCurrentUserId();
-		if (userId != null) {
-			try {
-				// 1. 사용자 정보 받아오기 (강황증권 계정 없을 때 생성하기 위함)
-				UserInfoDTO userInfo = mypageRepository.getUserInfoById(userId);
 
-				// 2. 강황증권 API로 {userId}에 해당하는 지갑 연결
-				String url = khUrl + "api/my/create-account";
-
-				Long walletId = externalApiClient.callApi(
-					url,
-					HttpMethod.POST,
-					userInfo,
-					new ParameterizedTypeReference<ExternalApiResponseDTO<Long>>() {
-					}
-				);
-
-				// 3. 연동할 지갑이 있으면, 우리 DB(user_certificate_links)에 저장
-				if (walletId != null) {
-					// 랜덤 토큰 및 만료 시간 생성 (테이블 NOT NULL 제약 조건 대응)
-					String randomAccessToken = UUID.randomUUID().toString();
-					String randomRefreshToken = UUID.randomUUID().toString();
-
-					// 4. DB 저장 (certificates_id는 1로 고정)
-					mypageRepository.upsertUserWalletLink(
-						userId,
-						walletId,
-						randomAccessToken,
-						randomRefreshToken
-					);
-					return walletId;
-				}
-			} catch (Exception e) {
-				System.err.println("[ERROR] 계좌 생성 및 연동 실패: " + e.getMessage());
-			}
+		if (userId == null) {
+			throw new BusinessException(ErrorCode.USER_NOT_FOUND);
 		}
-		return null; // 계좌가 없으면 null 반환
+
+		try {
+			// 1. 사용자 정보 받아오기 (강황증권 계정 없을 때 생성하기 위함)
+			UserInfoDTO userInfo = mypageRepository.getUserInfoById(userId);
+
+			// 2. 강황증권 API로 {userId}에 해당하는 지갑 연결
+			String url = khUrl + "api/my/create-account";
+			Long walletId = externalApiClient.callApi(
+				url,
+				HttpMethod.POST,
+				userInfo,
+				new ParameterizedTypeReference<ExternalApiResponseDTO<Long>>() {
+				}
+			);
+
+			if (walletId == null) {
+				throw new BusinessException(ErrorCode.EXTERNAL_API_ACC_NOT_FOUND);
+			}
+
+			// 3. 연동할 지갑이 있으면, 우리 DB(user_certificate_links)에 저장
+			// 랜덤 토큰 및 만료 시간 생성 (테이블 NOT NULL 제약 조건 대응)
+			String randomAccessToken = UUID.randomUUID().toString();
+			String randomRefreshToken = UUID.randomUUID().toString();
+
+			// 4. DB 저장 (certificates_id는 1로 고정)
+			mypageRepository.upsertUserWalletLink(
+				userId,
+				walletId,
+				randomAccessToken,
+				randomRefreshToken
+			);
+
+			return walletId;
+		} catch (Exception e) {
+			System.err.println("[ERROR] 계좌 생성 및 연동 실패: " + e.getMessage());
+			throw new BusinessException(ErrorCode.EXTERNAL_API_ERROR);
+		}
 	}
 
 	// 내 정보 조회

--- a/backend/src/main/java/com/animalfarm/backend/domain/mypage/dto/MypageWalletDTO.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/mypage/dto/MypageWalletDTO.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 @Setter
 public class MypageWalletDTO {
 
+	private Long walletId; // 지갑 번호
 	private String accountNo; // 계좌번호
 	private String bankName; // 은행명
 	private BigDecimal availableBalance; // 사용 가능 금액

--- a/backend/src/main/java/com/animalfarm/backend/global/http/ExternalApiClient.java
+++ b/backend/src/main/java/com/animalfarm/backend/global/http/ExternalApiClient.java
@@ -113,6 +113,7 @@ public class ExternalApiClient {
 			return webClient.method(method)
 				.uri(java.net.URI.create(secureUrl))
 				.header("User-Agent", "Mozilla/5.0")
+				.header("Accept", MediaType.APPLICATION_JSON_VALUE)
 				.retrieve()
 				.bodyToMono(responseType)
 				.block();

--- a/backend/src/main/resources/mapper/MypageMapper.xml
+++ b/backend/src/main/resources/mapper/MypageMapper.xml
@@ -73,34 +73,34 @@
 
     <insert id="upsertUserWalletLink">
         INSERT INTO user_certificate_links (
-        ucl_id,
-        user_id,
-        certificates_id,
-        access_token,
-        refresh_token,
-        token_expired_at,
-        refresh_token_expired_at,
-        created_at
+            ucl_id,
+            user_id,
+            certificates_id,
+            access_token,
+            refresh_token,
+            token_expired_at,
+            refresh_token_expired_at,
+            created_at
         )
         VALUES (
-        #{walletId},
-        #{userId},
-        1, -- 증권사 번호 1 고정
-        #{accessToken},
-        #{refreshToken},
-        NOW() + INTERVAL '1 hour',
-        NOW() + INTERVAL '30 days',
-        NOW()
+            #{walletId},
+            #{userId},
+            1, -- 증권사 번호 1 고정
+            #{accessToken},
+            #{refreshToken},
+            NOW() + INTERVAL '1 hour',
+            NOW() + INTERVAL '30 days',
+            NOW()
         )
-        ON CONFLICT (user_id)
+        ON CONFLICT (ucl_id)
         DO UPDATE SET
-        ucl_id = EXCLUDED.ucl_id,
-        certificates_id = 1,
-        access_token = EXCLUDED.access_token,
-        refresh_token = EXCLUDED.refresh_token,
-        token_expired_at = EXCLUDED.token_expired_at,
-        refresh_token_expired_at = EXCLUDED.refresh_token_expired_at,
-        updated_at = NOW()
+            user_id = EXCLUDED.user_id,
+            certificates_id = 1,
+            access_token = EXCLUDED.access_token,
+            refresh_token = EXCLUDED.refresh_token,
+            token_expired_at = EXCLUDED.token_expired_at,
+            refresh_token_expired_at = EXCLUDED.refresh_token_expired_at,
+            updated_at = NOW()
     </insert>
 
     <select id="selectJoinedProjectCards" resultType="MypageProjectDTO">

--- a/frontend/src/pages/mypage/components/myWallet/Account.tsx
+++ b/frontend/src/pages/mypage/components/myWallet/Account.tsx
@@ -1,6 +1,6 @@
-import Icon from "@/components/icon";
-import { numberFormatter, toNumber } from "./walletFormatters";
-import type { WalletInfoDTO } from "@/types/myPageType";
+import Icon from '@/components/icon';
+import { numberFormatter, toNumber } from './walletFormatters';
+import type { WalletInfoDTO } from '@/types/myPageType';
 
 interface AccountProps {
   walletInfo: WalletInfoDTO | null;
@@ -12,8 +12,6 @@ export default function Account({ walletInfo, loading = false }: AccountProps) {
   const availableAmount = walletInfo
     ? toNumber(walletInfo.availableBalance)
     : 0;
-  
-    console.log(walletInfo)
 
   return (
     <section className="mb-5 rounded-lg bg-white p-4 shadow-std md:p-6">
@@ -34,7 +32,7 @@ export default function Account({ walletInfo, loading = false }: AccountProps) {
               </div>
             ) : (
               <p className="font-body-02 text-gray-500">
-                {!loading ? "연동된 계좌가 없습니다." : "\u00A0"}
+                {!loading ? '연동된 계좌가 없습니다.' : '\u00A0'}
               </p>
             )}
           </div>

--- a/frontend/src/pages/mypage/components/myWallet/WalletLayout.tsx
+++ b/frontend/src/pages/mypage/components/myWallet/WalletLayout.tsx
@@ -5,86 +5,59 @@ import TabMenu from '@/components/common/TabMenu';
 import Icon from '@/components/icon';
 import { myPageApi } from '@/api/myPageApi';
 import PageHeader from '@/pages/mypage/components/PageHeader';
-import type { HoldingDTO, WalletInfoDTO } from '@/types/myPageType';
 import Investment from './Investment';
 import TokenTable from './TokenTable';
 import Account from './Account';
 import Modal from '@/components/common/Modal.tsx';
 import CreateAcc from './CreateAcc';
+import { useWalletInfo } from '../../hooks/useWalletInfo';
 
 export default function WalletLayout() {
   const [tab, setTab] = useState('HOLDINGS');
-  const [loading, setLoading] = useState(true);
-  const [holdingsLoading, setHoldingsLoading] = useState(true);
-  const [holdingsLoadingMore, setHoldingsLoadingMore] = useState(false);
-  const [holdingsPage, setHoldingsPage] = useState(1);
-  const [holdingsHasNext, setHoldingsHasNext] = useState(false);
-  const [nextHoldings, setNextHoldings] = useState<HoldingDTO[] | null>(null);
-  const [linking, setLinking] = useState(false);
-  const [walletInfo, setWalletInfo] = useState<WalletInfoDTO | null>(null);
-  const [holdings, setHoldings] = useState<HoldingDTO[]>([]);
+  const [isLinking, setIsLinking] = useState(false); // 계좌 연동 여부
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false); // 계좌 생성 여부 모달
   const [isErrorModalOpen, setIsErrorModalOpen] = useState<boolean>(false); // 계좌 생성 에러 모달
   const [isCreatingAcc, setIsCreatingAcc] = useState<boolean>(false); // 계좌 생성 프로세스 모달
   const [currentStep, setCurrentStep] = useState(1); // 계좌 생성 진행 단계
 
-  // 계좌 생성 프로세스 시작 시 타이머 작동
-  useEffect(() => {
-    let timer: NodeJS.Timeout;
+  // 1. 초기 지갑 존재 여부만 체크하기 위한 상태 (훅 호출 결정용)
+  const [initialWalletId, setInitialWalletId] = useState<number | undefined>(
+    undefined,
+  );
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
 
-    if (isCreatingAcc && currentStep < 4) {
-      timer = setTimeout(() => {
-        setCurrentStep((prev) => prev + 1);
-      }, 2000); // 2초마다 다음 단계로
-    }
+  // 2. 실시간 훅 사용
+  const {
+    walletInfo,
+    holdings,
+    loading: walletLoading,
+  } = useWalletInfo(initialWalletId);
 
-    return () => clearTimeout(timer); // 언마운트 시 타이머 정리
-  }, [isCreatingAcc, currentStep]);
-
-  const fetchWalletData = useCallback(async () => {
+  // 지갑 ID 가져와서 useWallet 훅 활성화
+  const checkWalletExists = useCallback(async () => {
     try {
+      setIsInitialLoading(true);
       const wallet = await myPageApi.getWalletInfo();
-      setWalletInfo(wallet);
+      if (wallet && wallet.walletId) {
+        setInitialWalletId(Number(wallet.walletId));
+      }
     } catch (error) {
-      console.error('지갑 정보 로드 실패', error);
+      console.error('지갑 조회 실패', error);
     } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const fetchHoldings = useCallback(async () => {
-    try {
-      setHoldingsLoading(true);
-      setHoldingsPage(1);
-      const [holdingList, nextPageList] = await Promise.all([
-        myPageApi.getHoldings(1),
-        myPageApi.getHoldings(2),
-      ]);
-      const firstPageItems = holdingList ?? [];
-      const prefetchedItems = nextPageList ?? [];
-      setHoldings(firstPageItems);
-      setNextHoldings(prefetchedItems);
-      setHoldingsHasNext(prefetchedItems.length > 0);
-    } catch (error) {
-      console.error('보유 토큰 로드 실패', error);
-      setHoldings([]);
-      setNextHoldings([]);
-      setHoldingsHasNext(false);
-    } finally {
-      setHoldingsLoading(false);
+      setIsInitialLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    fetchWalletData();
-    fetchHoldings();
-  }, [fetchWalletData, fetchHoldings]);
+    checkWalletExists();
+  }, []);
 
+  // 계좌 연동
   const handleLinkAccount = async () => {
     try {
-      setLinking(true);
+      setIsLinking(true);
       await myPageApi.linkAccount();
-      await Promise.all([fetchWalletData(), fetchHoldings()]);
+      await checkWalletExists(); // 연동 성공 시 지갑 ID 세팅하여 useWallet 활성화
     } catch (error) {
       if (error.response && error.response.data) {
         const errorRes = error.response.data; // ApiResponseDTO
@@ -100,33 +73,11 @@ export default function WalletLayout() {
         console.error('계좌 연동 실패', error);
       }
     } finally {
-      setLinking(false);
+      setIsLinking(false);
     }
   };
 
-  const handleLoadMoreHoldings = async () => {
-    if (holdingsLoading || holdingsLoadingMore || !holdingsHasNext) return;
-    const nextPage = holdingsPage + 1;
-    try {
-      setHoldingsLoadingMore(true);
-      const appendItems = nextHoldings ?? [];
-      if (appendItems.length === 0) {
-        setHoldingsHasNext(false);
-        return;
-      }
-      setHoldings((prev) => [...prev, ...appendItems]);
-      setHoldingsPage(nextPage);
-      const prefetchedFollowing = await myPageApi.getHoldings(nextPage + 1);
-      const followingItems = prefetchedFollowing ?? [];
-      setNextHoldings(followingItems);
-      setHoldingsHasNext(followingItems.length > 0);
-    } catch (error) {
-      console.error('보유 토큰 추가 로드 실패', error);
-    } finally {
-      setHoldingsLoadingMore(false);
-    }
-  };
-
+  // 계좌 생성 후 연동
   const handleCreateLinkAccount = async () => {
     try {
       // 1. 확인 모달 닫고 로딩/진행 모달 열기
@@ -136,7 +87,7 @@ export default function WalletLayout() {
 
       // 2. 실제 API 호출 (연동 시작)
       await myPageApi.createAndLinkAccount();
-      console.log('계좌 연동 성공');
+      await checkWalletExists(); // 연동 성공 시 지갑 ID 세팅하여 useWallet 활성화
     } catch (error: any) {
       // 3. 에러 발생 시 에러 모달 열기
       setIsErrorModalOpen(true);
@@ -146,36 +97,55 @@ export default function WalletLayout() {
     }
   };
 
+  // 계좌 생성 프로세스 타이머
+  useEffect(() => {
+    let timer: NodeJS.Timeout;
+
+    if (isCreatingAcc && currentStep < 4) {
+      timer = setTimeout(() => {
+        setCurrentStep((prev) => prev + 1);
+      }, 2000); // 2초마다 다음 단계로
+    }
+
+    return () => clearTimeout(timer); // 언마운트 시 타이머 정리
+  }, [isCreatingAcc, currentStep]);
+
   return (
     <div>
       <PageHeader
         title="나의 전자지갑"
         subtitle="연동된 증권 계좌와 실시간 투자 현황을 확인하세요."
         rightSlot={
-          !walletInfo && (
+          !isInitialLoading &&
+          !initialWalletId && (
             <Button
               variant="default"
               width={138}
               height={44}
               onClick={handleLinkAccount}
-              disabled={linking}
+              disabled={isLinking}
             >
               <span className="inline-flex items-center gap-1">
                 <Icon name="link" size={14} color="white" />
-                {linking ? '연동 중...' : '계좌 연동'}
+                {isLinking ? '연동 중...' : '계좌 연동'}
               </span>
             </Button>
           )
         }
       />
-      <Account walletInfo={walletInfo} loading={loading} />
-      <Investment walletInfo={walletInfo} />
+      <Account
+        walletInfo={walletInfo}
+        loading={isInitialLoading || walletLoading}
+      />
+      {walletInfo && <Investment walletInfo={walletInfo} />}
       <TabMenu
         className="mb-4"
         items={[{ text: '보유 토큰', value: 'HOLDINGS' }]}
         currentValue={tab}
         onTabChange={setTab}
       />
+      <TokenTable loading={false} holdings={holdings} />
+      {/* 
       <TokenTable loading={holdingsLoading} holdings={holdings} />
       {!holdingsLoading && holdings.length > 0 && holdingsHasNext ? (
         <div className="mt-6">
@@ -186,7 +156,7 @@ export default function WalletLayout() {
             {holdingsLoadingMore ? '불러오는 중...' : '+ 더보기'}
           </LoadMoreButton>
         </div>
-      ) : null}
+      ) : null} */}
 
       {isModalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
@@ -209,7 +179,7 @@ export default function WalletLayout() {
             onClose={() => {
               setIsCreatingAcc(false); // 모달 닫기
               setCurrentStep(1);
-              fetchWalletData(); // 계좌 정보 새로고침
+              checkWalletExists(); // 생성 완료 후 지갑 로드
             }}
           />
         </div>

--- a/frontend/src/pages/mypage/hooks/useWalletInfo.ts
+++ b/frontend/src/pages/mypage/hooks/useWalletInfo.ts
@@ -1,0 +1,170 @@
+import { myPageApi } from '@/api/myPageApi';
+import type {
+  HoldingDTO,
+  MarketPriceDTO,
+  WalletInfoDTO,
+  WalletUpdate,
+} from '@/types/myPageType';
+import WebSocketManager from '@/utils/WebSocketManager';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export const useWalletInfo = (walletId: number | undefined) => {
+  const [walletInfo, setWalletInfo] = useState<WalletInfoDTO | null>(null);
+  const [allHoldings, setAllHoldings] = useState<HoldingDTO[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // 1. 초기 진입 시 DB 데이터 로드
+  const fetchInitialData = useCallback(async () => {
+    if (!walletId) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+
+      const [info, list] = await Promise.all([
+        myPageApi.getWalletInfo(),
+        myPageApi.getHoldings(0), // 전체 조회
+      ]);
+
+      setWalletInfo(info);
+      setAllHoldings(list ?? []);
+    } catch (error) {
+      console.error('데이터 로드 실패:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [walletId]);
+
+  // 2. 실시간 지표 계산 (allHoldings나 walletInfo가 변할 때마다 실행)
+  const realTimeSummary = useMemo(() => {
+    if (!walletInfo) return null;
+
+    const cash = Number(walletInfo.cashBalance);
+    const frozen = Number(walletInfo.frozenAmount);
+    const availableBalance = cash - frozen;
+
+    // 리스트 내 개별 항목들의 marketValue 합산
+    const totalMarketValue = allHoldings.reduce(
+      (sum, h) => sum + Number(h.marketValue || 0),
+      0,
+    );
+    const totalPurchased = Number(walletInfo.totalPurchasedValue);
+
+    const totalBalance = cash + totalMarketValue;
+    const profitLoss = totalMarketValue - totalPurchased;
+    const profitLossRate =
+      totalPurchased === 0 ? 0 : (profitLoss / totalPurchased) * 100;
+
+    return {
+      ...walletInfo,
+      availableBalance,
+      totalMarketValue,
+      totalBalance,
+      profitLoss,
+      profitLossRate,
+    };
+  }, [walletInfo, allHoldings]);
+
+  useEffect(() => {
+    if (!walletId) return;
+    let walletSub: string;
+    let priceSub: string;
+
+    fetchInitialData().then(() => {
+      const url = import.meta.env.VITE_WS_URL;
+      WebSocketManager.connect(url, () => {
+        // [채널 A] 개인 지갑 업데이트 (체결/취소/동결 발생 시)
+        walletSub = `wallet-${walletId}`;
+        WebSocketManager.subscribe(
+          walletSub,
+          `/topic/wallet/${walletId}`,
+          (data: WalletUpdate) => {
+            // 1. 상단 잔고 정보 갱신 (현금, 동결금액, 총매입금액)
+            setWalletInfo((prev) =>
+              prev
+                ? {
+                    ...prev,
+                    cashBalance: data.cashBalance,
+                    frozenAmount: data.frozenAmount,
+                    totalPurchasedValue: data.totalPurchasedValue,
+                  }
+                : null,
+            );
+
+            // 2. 리스트 내 수량 및 매입가 갱신
+            setAllHoldings((prev) => {
+              const idx = prev.findIndex((h) => h.tokenId === data.tokenId);
+              // 수량이 0이면 리스트에서 제거 (전량 매도 등)
+              if (data.tokenQty <= 0)
+                return prev.filter((h) => h.tokenId !== data.tokenId);
+
+              const next = [...prev];
+              if (idx !== -1) {
+                // 기존 종목 업데이트
+                next[idx] = {
+                  ...next[idx],
+                  tokenBalance: data.tokenQty,
+                  purchasedValue: data.tokenPurchasedVal,
+                };
+              } else {
+                // 신규 종목 진입
+                next.unshift({
+                  tokenId: data.tokenId,
+                  tokenName: data.tokenName,
+                  tickerSymbol: data.tickerSymbol,
+                  tokenBalance: data.tokenQty,
+                  purchasedValue: data.tokenPurchasedVal,
+                  marketValue: 0, // 다음 시세 소켓에서 업데이트됨
+                  profitLoss: 0,
+                  profitLossRate: 0,
+                });
+              }
+              return next;
+            });
+          },
+        );
+
+        // [채널 B] 공통 시세 업데이트 (내 거래와 상관없이 가격 변동 시)
+        priceSub = `price-all`;
+        WebSocketManager.subscribe(
+          priceSub,
+          `/topic/market/prices`,
+          (priceData: MarketPriceDTO) => {
+            setAllHoldings((prev) =>
+              prev.map((h) => {
+                if (h.tokenId === priceData.tokenId) {
+                  const currentPrice = Number(priceData.currentPrice);
+                  const newMarketValue = Number(h.tokenBalance) * currentPrice;
+                  const profitLoss = newMarketValue - Number(h.purchasedValue);
+
+                  return {
+                    ...h,
+                    marketValue: newMarketValue,
+                    profitLoss: profitLoss,
+                    profitLossRate:
+                      Number(h.purchasedValue) === 0
+                        ? 0
+                        : (profitLoss / Number(h.purchasedValue)) * 100,
+                  };
+                }
+                return h;
+              }),
+            );
+          },
+        );
+      });
+    });
+
+    return () => {
+      WebSocketManager.unsubscribe(walletSub);
+      WebSocketManager.unsubscribe(priceSub);
+    };
+  }, [walletId, fetchInitialData]);
+
+  return {
+    walletInfo: realTimeSummary,
+    holdings: allHoldings,
+    loading,
+  };
+};

--- a/frontend/src/types/myPageType.ts
+++ b/frontend/src/types/myPageType.ts
@@ -1,4 +1,5 @@
 export interface WalletInfoDTO {
+  walletId: number;
   accountNo: string;
   bankName: string;
   availableBalance: number | string;
@@ -12,6 +13,7 @@ export interface WalletInfoDTO {
 }
 
 export interface HoldingDTO {
+  tokenId: number;
   tokenName: string;
   tickerSymbol: string;
   tokenBalance: number | string;
@@ -25,13 +27,13 @@ export interface MyTransactionHistDTO {
   transactionId: number;
   createdAt: string;
   transactionType:
-    | "BUY"
-    | "SELL"
-    | "PASS"
-    | "FAIL"
-    | "CANCELLED"
-    | "DIVIDEND"
-    | "BURN"
+    | 'BUY'
+    | 'SELL'
+    | 'PASS'
+    | 'FAIL'
+    | 'CANCELLED'
+    | 'DIVIDEND'
+    | 'BURN'
     | string;
   tokenName: string | null;
   tickerSymbol: string | null;
@@ -96,4 +98,31 @@ export interface MyPageProjectDTO {
   periodText?: string | null;
   statusText1?: string | null;
   statusText2?: string | null;
+}
+
+// 전자 지갑 정보 (웹소켓 통신용)
+export interface WalletUpdate {
+  walletId: number;
+  tokenId: number;
+  tokenName: string;
+  tickerSymbol: string;
+  frozenAmount: number; // 동결 금액
+  cashBalance: number; // 총 예수금
+  totalPurchasedValue: number; // 총 매입 금액
+  tokenQty: number; // 해당 토큰의 총 수량
+  tokenPurchasedVal: number; // 해당 토큰의 총 매입금액
+}
+
+// 보유 토큰 정보
+export interface HoldingShortDTO {
+  tokenName: string;
+  tickerSymbol: string;
+  quantity: number;
+  purchasedValue: number;
+}
+
+// 시장가 정보 (웹소켓 통신용)
+export interface MarketPriceDTO {
+  tokenId: number;
+  currentPrice: number;
 }


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 마이페이지 전자지갑 실시간 반영
- 계좌 연동 실패 시 실패 모달 띄우기
- ❗️체결 발생 시 해당 체결가를 바탕으로 평가금액 등을 계산하는데, 현재 레디스에 가격 정보가 들어가있지 않아 계산 안 됨

## 📝 변경 사항 (Key Changes)
- [ ] useWalletInfo 훅을 통해 전자지갑 정보를 실시간으로 반영
- [ ] 백엔드에서 계좌 연동 실패 시 BusinessException 던져서 실패 모달 띄우도록 변경

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 연동 실패 모달 | <img width="365" height="289" alt="image" src="https://github.com/user-attachments/assets/2f8bf252-97b2-4e19-9611-28ab4577f4ba" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #122 

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [ ] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [ ] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [ ] 변경 사항에 대한 테스트를 완료하였는가?
- [ ] 관련 문서를 업데이트하였는가?
