### PR TITLE
[FEAT] 뉴스 생성 백엔드

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/config/LlmConfig.java
+++ b/backend/src/main/java/com/animalfarm/backend/config/LlmConfig.java
@@ -1,0 +1,28 @@
+package com.animalfarm.backend.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@PropertySource("classpath:config/llmAPI.properties")
+public class LlmConfig {
+
+	@Value("${openai.api.connect-timeout}")
+	private int connectTimeout;
+
+	@Value("${openai.api.read-timeout}")
+	private int readTimeout;
+
+	@Bean
+	public RestTemplate llmRestTemplate() {
+		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+		factory.setConnectTimeout(connectTimeout);
+		factory.setReadTimeout(readTimeout);
+
+		return new RestTemplate(factory);
+	}
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/LlmService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/LlmService.java
@@ -1,0 +1,120 @@
+package com.animalfarm.backend.domain.news;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.animalfarm.backend.domain.news.dto.LlmResponseDTO;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LlmService {
+
+	private final RestTemplate llmRestTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Value("${openai.api.url}")
+	private String openAiApiUrl;
+
+	@Value("${openai.api.key}")
+	private String apiKey;
+
+	@Value("${openai.api.model:gpt-4o-mini}") // 기본값으로 빠르고 저렴한 gpt-4o-mini 사용
+	private String apiModel;
+
+	public LlmResponseDTO ask(String factData, String type) {
+
+		// 1. 완벽한 프롬프트 엔지니어링 (시스템 프롬프트)
+		String systemPrompt = buildSystemPrompt(type);
+
+		// 2. OpenAI API 요청 바디(Body) 구성
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_JSON);
+		headers.setBearerAuth(apiKey);
+
+		Map<String, Object> messageSystem = Map.of("role", "system", "content", systemPrompt);
+		Map<String, Object> messageUser = Map.of("role", "user", "content", "분석할 데이터: " + factData);
+
+		Map<String, Object> requestBody = Map.of(
+			"model", apiModel,
+			"messages", List.of(messageSystem, messageUser),
+			"temperature", 0.2, // 환각 방지를 위해 창의성을 낮추고 팩트 기반으로 제한 (0.0 ~ 0.3 권장)
+			"response_format", Map.of("type", "json_object") // 반드시 JSON으로 응답하도록 강제
+		);
+
+		HttpEntity<Map<String, Object>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+		// 3. API 호출 및 예외 처리
+		try {
+			ResponseEntity<Map> response = llmRestTemplate.postForEntity(openAiApiUrl, requestEntity, Map.class);
+
+			// 응답 JSON에서 content 추출
+			Map<String, Object> responseBody = response.getBody();
+			List<Map<String, Object>> choices = (List<Map<String, Object>>)responseBody.get("choices");
+			Map<String, Object> message = (Map<String, Object>)choices.get(0).get("message");
+			String content = (String)message.get("content");
+
+			// String(JSON) -> LlmResponseDTO 객체로 매핑
+			return objectMapper.readValue(content, LlmResponseDTO.class);
+
+		} catch (Exception e) {
+			log.error("[LLM API Error] 뉴스 생성 실패: {}", e.getMessage());
+			// 실패 시 기본 더미 반환 (서버 다운 방지)
+			return new LlmResponseDTO(
+				"일시적인 시스템 오류로 요약을 생성할 수 없습니다.",
+				"시장 데이터를 실시간으로 수집하고 있습니다. 잠시 후 다시 확인해주세요."
+			);
+		}
+	}
+
+	// 프롬프트 조립 메서드 (기획서 예시 반영)
+	private String buildSystemPrompt(String type) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("당신은 24시간 스마트팜 STO 거래소의 수석 시황 분석가입니다.\n")
+			.append("제공된 시장 통계(등락률, ADR, 대금)와 특징주 데이터를 분석하여, 종합 마감 시황 뉴스를 작성하세요.\n\n");
+
+		sb.append("【스마트팜 전용 특징주 발생 시나리오 리스트】\n")
+			.append("[호재 시나리오 - 특징주 등락률이 양수(+)일 때 자율 선택]\n")
+			.append("- 최신 AI 양액 제어 알고리즘 도입으로 생산량 30% 증대 성공\n")
+			.append("- 대형 유통사(마트, 백화점)와 프리미엄 농산물 독점 공급 계약 체결\n")
+			.append("- LED 파장 최적화를 통해 영양소 2배 증대 기술 특허 취득\n")
+			.append("[악재 시나리오 - 특징주 등락률이 음수(-)일 때 자율 선택]\n")
+			.append("- 중앙 IoT 온습도 제어 센서 통신 장애로 인한 일시적 생육 불안정\n")
+			.append("- 스마트팜 시설 내 치명적인 바이러스 유입으로 방역 비상\n")
+			.append("- 미승인 불법 유전자 변형(GMO) 종자 밀수 및 재배 적발로 인한 농장 폐쇄 조치\n")
+			.append("- 전력 공급망 이상 및 비상 발전기 가동 지연에 따른 생산 차질 우려\n\n");
+
+		sb.append("【필수 작성 지침】\n")
+			.append(
+				"1. [수치 포맷팅]: 제공된 팩트 데이터의 수치를 기사에 적극적으로 인용하되, 모든 비율(%) 수치는 반드시 **소수점 첫째 자리**까지만 작성하세요 (예: 1468.22% -> 1468.2%, 250% -> 250.0%).\n")
+			.append(
+				"2. [호가 가독성]: 매수/매도 잔량 등 크기가 큰 원시 숫자(예: 552601583)는 '약 5억 5천만', '약 9천 3백' 등으로 독자가 읽기 편하게 한글 단위로 변환하여 작성하세요.\n")
+			.append("3. [전체 시황]: 본문 첫 문단에는 평균등락률, ADR, 대금증감률 수치를 인용하여 시장 전체의 투심과 유동성 흐름을 객관적으로 서술하세요.\n")
+			.append(
+				"4. [특징주 시나리오 반영]: 특징주가 있다면, 해당 종목의 등락률과 대금증감률, 잔량 수치를 명시하고, 등락률 부호(+/-)에 맞춰 위 시나리오 리스트 중 하나를 골라 주가 변동의 원인으로 자연스럽게 결합하세요.\n")
+			.append("5. 절대 외부의 날씨(폭우 등)나 제공되지 않은 정보를 지어내지 마세요.\n\n");
+
+		sb.append("【출력 포맷 및 예시 (JSON)】\n")
+			.append("반드시 아래 JSON 구조로만 반환하세요:\n")
+			.append("{\n")
+			.append("  \"shortSummary\": \"스마트팜 STO 평균 1.5% 상승... 지리산 꾸지뽕 1호 AI 알고리즘 도입에 수급 집중\",\n")
+			.append(
+				"  \"textBody\": \"금일 스마트팜 STO 시장은 평균 등락률 +1.5%를 기록하며 전반적인 강세 흐름을 연출했습니다. 상승 종목이 우위를 점하며 등락비율(ADR)은 135.0%로 단기 과열권 진입 양상이 관찰됩니다. 반면 최근 3시간의 전체 거래대금은 직전 대비 20.5% 감소하며 유동성이 다소 위축되는 엇갈린 흐름을 보였습니다. 개별 특징주로는 지리산 꾸지뽕 1호가 거래대금이 120.0% 폭증하며 +8.5%의 강한 상승세를 보였습니다. 매도 잔량은 0인 반면 약 5억 5천만 규모의 매수 대기 물량이 쌓이는 극단적인 매수 쏠림이 나타났습니다. 이는 최신 AI 양액 제어 알고리즘 도입으로 생산량 30% 증대 성공 소식이 전해지며 투자 심리를 강하게 자극한 것으로 풀이됩니다.\"\n")
+			.append("}");
+
+		return sb.toString();
+	}
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsController.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsController.java
@@ -1,0 +1,48 @@
+package com.animalfarm.backend.domain.news;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.animalfarm.backend.domain.news.dto.MarketNewsDTO;
+import com.animalfarm.backend.global.http.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/news")
+@RequiredArgsConstructor
+public class MarketNewsController {
+
+	private final MarketNewsRepository newsRepository;
+	private final MarketNewsService marketNewsService;
+
+	// 1. 글로벌 뉴스 전체 리스트 조회
+	@GetMapping("/global/list")
+	public ApiResponse<List<MarketNewsDTO>> getGlobalNewsList() {
+		List<MarketNewsDTO> list = newsRepository.selectNewsByType("GLOBAL");
+		return ApiResponse.messageWithData("글로벌 뉴스 리스트 조회 성공", list);
+	}
+
+	// 2. 글로벌 뉴스 상세 조회 (newsId 기반)
+	@GetMapping("/global/{newsId}")
+	public ApiResponse<MarketNewsDTO> getGlobalNewsDetail(@PathVariable Long newsId) {
+		MarketNewsDTO detail = newsRepository.selectNewsById(newsId);
+
+		if (detail == null) {
+			// 커스텀 예외 처리가 있다면 변경하셔도 좋습니다.
+			return ApiResponse.messageWithData("해당 뉴스를 찾을 수 없습니다.", null);
+		}
+		return ApiResponse.messageWithData("글로벌 뉴스 상세 조회 성공", detail);
+	}
+
+	// 3. 글로벌 뉴스 실행 (발행)
+	@GetMapping("/global/publish")
+	public ApiResponse<String> publishGlobalNews() {
+		marketNewsService.generateGlobalNews();
+		return ApiResponse.messageWithData("글로벌 뉴스 발행 성공", "콘솔 로그를 확인하세요.");
+	}
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsRepository.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsRepository.java
@@ -1,0 +1,20 @@
+package com.animalfarm.backend.domain.news;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.animalfarm.backend.domain.news.dto.MarketNewsDTO;
+
+@Mapper // MyBatis 매퍼 인터페이스
+public interface MarketNewsRepository {
+
+	// 뉴스 저장
+	void saveNews(MarketNewsDTO newsDTO);
+
+	// 뉴스 타입별 조회 (GLOBAL/TOKEN)
+	List<MarketNewsDTO> selectNewsByType(String newsType);
+
+	// 특정 뉴스 상세  조회
+	MarketNewsDTO selectNewsById(Long newsId);
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsScheduler.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsScheduler.java
@@ -1,0 +1,22 @@
+package com.animalfarm.backend.domain.news;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarketNewsScheduler {
+
+	private final MarketNewsService newsService;
+
+	// 02시, 08시, 14시, 20시 (하루 4회, 6시간 간격)
+	@Scheduled(cron = "0 0 2,8,14,20 * * *")
+	public void runGlobalMarketNews() {
+		log.info("[Scheduler] 통합 마켓 브리핑 생성 프로세스 시작");
+		newsService.generateGlobalNews();
+	}
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/MarketNewsService.java
@@ -1,0 +1,312 @@
+package com.animalfarm.backend.domain.news;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.animalfarm.backend.domain.news.dto.LlmResponseDTO;
+import com.animalfarm.backend.domain.news.dto.MarketNewsDTO;
+import com.animalfarm.backend.domain.token.dto.CandleDTO;
+import com.animalfarm.backend.domain.token.dto.OrderPriceDTO;
+import com.animalfarm.backend.domain.token.dto.TokenListDTO;
+import com.animalfarm.backend.global.dto.ExternalApiResponseDTO;
+import com.animalfarm.backend.global.http.ExternalApiClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketNewsService {
+
+	private final ExternalApiClient externalApiClient;
+	private final MarketNewsRepository newsRepository;
+	private final LlmService llmService;
+
+	// 강황증권 API 베이스 URL
+	private final String KH_API_BASE = "https://kh-holdings.cloud";
+
+	// 분석 기준 수치 (기획서 기반 튜닝)
+	//private static final BigDecimal MIN_VOL_THRESHOLD = new BigDecimal("0"); // 최소 거래대금 1천만 원, 테스트 10만원
+	private static final BigDecimal VOL_SURGE_THRESHOLD = new BigDecimal("0.5");    // 직전 대비 거래량 증가율 50%
+	private static final BigDecimal VOLATILITY_THRESHOLD = new BigDecimal("0.03");  // 가격 변동성 3%
+	private static final BigDecimal IMBALANCE_THRESHOLD = new BigDecimal("2.0");    // 호가 불균형 2배
+
+	/**
+	 * GLOBAL 뉴스 생성
+	 */
+	@Transactional
+	public void generateGlobalNews() {
+		try {
+			List<TokenListDTO> tokens = fetchAllTokens();
+			if (tokens == null || tokens.isEmpty())
+				return;
+
+			// ⭐ 핵심: 6시간 사이클을 전반전 3시간 / 후반전 3시간으로 분할
+			long endSec = System.currentTimeMillis() / 1000;
+			long startSec = endSec - (3 * 60 * 60);       // 최근 3시간 (후반전)
+			long prevStartSec = startSec - (3 * 60 * 60); // 직전 3시간 (전반전)
+
+			log.info("[통합 마켓 브리핑] 3H vs 3H 모멘텀 및 자체 등락률 분석 시작");
+
+			// [통계용 변수들]
+			BigDecimal totalRecentVol = BigDecimal.ZERO; // 최근 3시간 총 대금
+			BigDecimal totalPrevVol = BigDecimal.ZERO;   // 직전 3시간 총 대금
+			int upCount = 0;
+			int downCount = 0;
+			int steadyCount = 0;
+			double totalChangeRateSum = 0; // 평균 등락률 계산용
+			int validChangeRateCount = 0;
+			StringBuilder impactfulTokensReport = new StringBuilder();
+			List<String> highlightTokenNamesList = new ArrayList<>(); // UI용 특징주 이름 모음
+
+			// 1. 개별 종목 전수조사 및 통계 집계
+			for (TokenListDTO token : tokens) {
+				Long id = token.getTokenId();
+				try {
+					List<CandleDTO> recentCandles = fetchCandles(id, startSec, endSec);
+					List<CandleDTO> prevCandles = fetchCandles(id, prevStartSec, startSec);
+					List<OrderPriceDTO> buys = fetchBuyOrders(id);
+					List<OrderPriceDTO> sells = fetchSellOrders(id);
+
+					BigDecimal recentVol = calculateTotalVolume(recentCandles);
+					BigDecimal prevVol = calculateTotalVolume(prevCandles);
+
+					totalRecentVol = totalRecentVol.add(recentVol);
+					totalPrevVol = totalPrevVol.add(prevVol);
+
+					// 등락 종목 수 카운트 자체 등락률 직접 계산
+					BigDecimal currentChangeRate = BigDecimal.ZERO;
+
+					if (prevCandles != null && !prevCandles.isEmpty() && token.getMarketPrice() != null) {
+						// 직전 3시간의 마지막 캔들 종가를 기준가(Baseline)로 잡음
+						BigDecimal baselinePrice = prevCandles.get(prevCandles.size() - 1).getClosingPrice();
+						BigDecimal currentPrice = token.getMarketPrice(); // 현재가
+
+						if (baselinePrice.compareTo(BigDecimal.ZERO) > 0) {
+							// (현재가 - 기준가) / 기준가 * 100
+							currentChangeRate = currentPrice.subtract(baselinePrice)
+								.divide(baselinePrice, 4, RoundingMode.HALF_UP)
+								.multiply(new BigDecimal("100"));
+						}
+					}
+
+					// 자체 계산한 등락률로 통계 집계
+					int compare = currentChangeRate.compareTo(BigDecimal.ZERO);
+					if (compare > 0)
+						upCount++;
+					else if (compare < 0)
+						downCount++;
+					else
+						steadyCount++;
+
+					totalChangeRateSum += currentChangeRate.doubleValue();
+					validChangeRateCount++;
+
+					// 특징주(isImpactful) 조건 통과 시
+					if (isImpactful(recentCandles, prevVol, recentVol, buys, sells)) {
+						double volGrowth = prevVol.compareTo(BigDecimal.ZERO) > 0 ?
+							recentVol.subtract(prevVol).divide(prevVol, 2, RoundingMode.HALF_UP).doubleValue() * 100 :
+							0;
+
+						impactfulTokensReport.append(String.format("[%s: 3H등락률 %.2f%%, 대금증감률 %.0f%%, 매수잔량 %s/매도잔량 %s] ",
+							token.getTokenName(), currentChangeRate.doubleValue(), volGrowth,
+							sumOrderVolume(buys).toPlainString(), sumOrderVolume(sells).toPlainString()
+						));
+
+						// 💡 UI 위젯에 띄워줄 토큰 이름 수집
+						highlightTokenNamesList.add(token.getTokenName());
+					}
+				} catch (Exception e) {
+					log.warn("종목 {} 분석 스킵: {}", id, e.getMessage());
+				}
+			}
+
+			// =================================================================
+			// 2. KOSPI 3대 지표 산출 (지수 등락률, ADR, 거래대금 증감)
+			// =================================================================
+
+			// ① 평균 등락률 (전체 토큰의 ChangeRate 평균)
+			double averageChangeRate = validChangeRateCount > 0 ? (totalChangeRateSum / validChangeRateCount) : 0.0;
+
+			// ② ADR (등락비율: 상승종목수 / 하락종목수 * 100)
+			double adr = (downCount == 0) ? (upCount > 0 ? 200.0 : 100.0) : ((double)upCount / downCount) * 100;
+
+			// ③ 전체 시장 거래대금 증감률 (후반전 3H vs 전반전 3H)
+			double marketVolGrowth = 0;
+			if (totalPrevVol.compareTo(BigDecimal.ZERO) > 0) {
+				marketVolGrowth =
+					totalRecentVol.subtract(totalPrevVol).divide(totalPrevVol, 4, RoundingMode.HALF_UP).doubleValue()
+						* 100;
+			}
+
+			// 3. LLM에게 던져줄 정제된 팩트 데이터 조립
+			String factData = String.format(
+				"평균등락률:%.2f%%, ADR:%.1f%%, 총거래대금:%s, 전체대금증감률(최근3H vs 직전3H):%.1f%%, [통계] 상승:%d/하락:%d/보합:%d, [특징주(수급/호가쏠림)]: %s",
+				averageChangeRate, adr, totalRecentVol.toPlainString(), marketVolGrowth,
+				upCount, downCount, steadyCount,
+				impactfulTokensReport.length() > 0 ? impactfulTokensReport.toString() : "없음"
+			);
+
+			log.info("[통합 분석 완료] LLM 전달 팩트 -> {}", factData);
+
+			LlmResponseDTO llmRes = llmService.ask(factData, "GLOBAL");
+
+			// 💡 UI 위젯이 깨지지 않도록 최대 2개까지만 잘라서 문자열로 조립!
+			String highlightTokensStr = highlightTokenNamesList.stream()
+				.limit(2)
+				.collect(Collectors.joining(", "));
+
+			MarketNewsDTO newsDTO = MarketNewsDTO.builder()
+				.newsType("GLOBAL")
+				.summaryShort(llmRes.getShortSummary())
+				.summaryText(llmRes.getTextBody())
+				// 💡 [추가됨] 프론트엔드 UI 위젯이 그대로 가져다 쓸 데이터 직접 삽입!
+				.avgChangeRate(averageChangeRate)
+				.adrValue(adr)
+				.volGrowthRate(marketVolGrowth)
+				.highlightTokens(highlightTokensStr)
+				.build();
+
+			newsRepository.saveNews(newsDTO);
+			log.info("[통합 마켓 브리핑] DB 저장 완료");
+
+		} catch (Exception e) {
+			log.error("[통합 시황 실패]: {}", e.getMessage());
+		}
+	}
+
+	// --- 비즈니스 로직(필터링 및 계산) ---
+
+	private boolean isImpactful(List<CandleDTO> candles, BigDecimal prevVol, BigDecimal recentVol,
+		List<OrderPriceDTO> buys, List<OrderPriceDTO> sells) {
+		int matchCount = 0;
+
+		log.info("▶ 필터링 검사 시작 [이전 3H 대금: {}, 최근 3H 대금: {}]", prevVol, recentVol);
+
+		// 조건 1. 상대적 거래량 급증 (직전 3H 대비 50% 이상 증가)
+		if (prevVol.compareTo(BigDecimal.ZERO) > 0) {
+			BigDecimal volIncreaseRate = recentVol.subtract(prevVol)
+				.divide(prevVol, 4, RoundingMode.HALF_UP);
+			log.info("  - 1. 거래량 증가율: {} (기준치: {})", volIncreaseRate, VOL_SURGE_THRESHOLD);
+			if (volIncreaseRate.compareTo(VOL_SURGE_THRESHOLD) >= 0)
+				matchCount++;
+		} else if (recentVol.compareTo(BigDecimal.ZERO) > 0) {
+			log.info("  - 1. 거래량 증가율: 이전 거래 없음 (급증 간주)");
+			matchCount++; // 이전 거래량이 0인데 현재 거래량이 발생했다면 급증으로 간주
+		}
+
+		// 조건 2. 가격 변동성 (고가-저가 갭)
+		BigDecimal high = candles.stream()
+			.map(CandleDTO::getHighPrice)
+			.max(BigDecimal::compareTo)
+			.orElse(BigDecimal.ZERO);
+		BigDecimal low = candles.stream()
+			.map(CandleDTO::getLowPrice)
+			.min(BigDecimal::compareTo)
+			.orElse(BigDecimal.ZERO);
+		if (low.compareTo(BigDecimal.ZERO) > 0) {
+			BigDecimal priceGap = high.subtract(low).divide(low, 4, RoundingMode.HALF_UP);
+			log.info("  - 2. 가격 변동성: {} (고가: {}, 저가: {})", priceGap, high, low);
+			if (priceGap.compareTo(VOLATILITY_THRESHOLD) >= 0)
+				matchCount++;
+		}
+
+		// 조건 3. 호가 불균형
+		BigDecimal buySum = sumOrderVolume(buys);
+		BigDecimal sellSum = sumOrderVolume(sells);
+		log.info("  - 3. 호가 잔량 (매수: {}, 매도: {})", buySum, sellSum);
+		if (sellSum.compareTo(BigDecimal.ZERO) > 0) {
+			BigDecimal ratio = buySum.divide(sellSum, 2, RoundingMode.HALF_UP);
+			log.info("  - 3. 매수/매도 비율: {}", ratio);
+			if (ratio.compareTo(IMBALANCE_THRESHOLD) >= 0 || ratio.compareTo(new BigDecimal("0.5")) <= 0) {
+				matchCount++;
+			}
+		} else if (buySum.compareTo(BigDecimal.ZERO) > 0) {
+			log.info("  - 3. 극단적 불균형: 매도 잔량 0, 매수 대기만 존재 (특징주 조건 충족)");
+			matchCount++; // 매도 잔량이 0이고 매수 잔량만 있는 극단적 상황
+		}
+		log.info("▷ 최종 만족 조건 개수: {}/3 -> {}", matchCount, matchCount >= 2 ? "통과(뉴스발행)" : "탈락(스킵)");
+		return matchCount >= 2; // 3개 중 2개 이상 만족 시 true
+	}
+
+	// --- External API Call Helpers ---
+
+	private List<TokenListDTO> fetchAllTokens() {
+		return externalApiClient.callApi(
+			KH_API_BASE + "/api/market", // 전체 토큰 리스트 엔드포인트 수정
+			HttpMethod.GET, null,
+			new ParameterizedTypeReference<ExternalApiResponseDTO<List<TokenListDTO>>>() {
+			}
+		);
+	}
+
+	private List<CandleDTO> fetchCandles(Long id, long s, long e) {
+		return externalApiClient.callApi(
+			String.format("%s/api/market/candles/%d?unit=60&start=%d&end=%d", KH_API_BASE, id, s, e),
+			HttpMethod.GET, null,
+			new ParameterizedTypeReference<ExternalApiResponseDTO<List<CandleDTO>>>() {
+			}
+		);
+	}
+
+	private List<OrderPriceDTO> fetchBuyOrders(Long id) {
+		return externalApiClient.callApi(
+			KH_API_BASE + "/api/market/order/buy/" + id, // 매수 엔드포인트 분리
+			HttpMethod.GET, null,
+			new ParameterizedTypeReference<ExternalApiResponseDTO<List<OrderPriceDTO>>>() {
+			}
+		);
+	}
+
+	private List<OrderPriceDTO> fetchSellOrders(Long id) {
+		return externalApiClient.callApi(
+			KH_API_BASE + "/api/market/order/sell/" + id, // 매도 엔드포인트 분리
+			HttpMethod.GET, null,
+			new ParameterizedTypeReference<ExternalApiResponseDTO<List<OrderPriceDTO>>>() {
+			}
+		);
+	}
+
+	private BigDecimal calculateTotalVolume(List<CandleDTO> candles) {
+		return candles.stream()
+			.map(candle -> {
+				// 1. API가 tradeAmount(거래대금)를 정상적으로 줬다면 그대로 사용
+				if (candle.getTradeAmount() != null) {
+					return candle.getTradeAmount();
+				}
+
+				// 2. tradeAmount가 null이라면? -> (거래량 * 종가)로 직접 거래대금 계산!
+				if (candle.getTradeVolume() != null && candle.getClosingPrice() != null) {
+					return candle.getTradeVolume().multiply(candle.getClosingPrice());
+				}
+
+				// 둘 다 없으면 0원 처리
+				return BigDecimal.ZERO;
+			})
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	private BigDecimal sumOrderVolume(List<OrderPriceDTO> orders) {
+		if (orders == null)
+			return BigDecimal.ZERO;
+		return orders.stream().map(OrderPriceDTO::getTotalVolume)
+			.filter(vol -> vol != null)
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+	}
+
+	private String buildTokenFactData(TokenListDTO token, BigDecimal recentVol, BigDecimal prevVol,
+		List<OrderPriceDTO> buys, List<OrderPriceDTO> sells) {
+		return String.format("종목명:%s, 현재가:%s, 직전3H-대금:%s, 최근3H-대금:%s, 매수잔량:%s, 매도잔량:%s",
+			token.getTokenName(), token.getMarketPrice(), prevVol.toPlainString(), recentVol.toPlainString(),
+			sumOrderVolume(buys).toPlainString(), sumOrderVolume(sells).toPlainString());
+	}
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/dto/LlmResponseDTO.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/dto/LlmResponseDTO.java
@@ -1,0 +1,13 @@
+package com.animalfarm.backend.domain.news.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LlmResponseDTO {
+	private String shortSummary; // 1줄 요약
+	private String textBody;     // 데이터 분석 본문
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/news/dto/MarketNewsDTO.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/news/dto/MarketNewsDTO.java
@@ -1,0 +1,31 @@
+package com.animalfarm.backend.domain.news.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+// DB 저장 및 조회용 뉴스 DTO
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MarketNewsDTO {
+	private Long newsId;
+	private Long tokenId;       // GLOBAL 뉴스일 경우 null
+	private String summaryShort; // 1줄 요약
+	private String summaryText;  // 데이터 분석 본문
+	private String newsType;    // GLOBAL, TOKEN
+	private LocalDateTime createdAt;
+
+	// 👇 [추가됨] 프론트엔드 UI 위젯용 정량 데이터 트랙
+	private Double avgChangeRate;     // 평균 등락률 (예: 1.52)
+	private Double adrValue;          // 등락비율 (예: 250.0)
+	private Double volGrowthRate;     // 전체 대금 증감률 (예: -68.1)
+	private String highlightTokens;   // 특징주 이름 모음 (예: "지리산 꾸지뽕 1호, 과수원 2호")
+
+}

--- a/backend/src/main/resources/mapper/MarketNewsMapper.xml
+++ b/backend/src/main/resources/mapper/MarketNewsMapper.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.animalfarm.backend.domain.news.MarketNewsRepository">
+
+    <insert id="saveNews" parameterType="MarketNewsDTO">
+        INSERT INTO marketnews (
+        token_id,
+        news_type,
+        summary_short,
+        summary_text,
+        avg_change_rate,
+        adr_value,
+        vol_growth_rate,
+        highlight_tokens,
+        created_at
+        ) VALUES (
+        #{tokenId},
+        #{newsType},
+        #{summaryShort},
+        #{summaryText},
+        #{avgChangeRate},
+        #{adrValue},
+        #{volGrowthRate},
+        #{highlightTokens},
+        NOW()
+        )
+    </insert>
+
+    <select id="selectNewsByType" parameterType="string" resultType="MarketNewsDTO">
+        SELECT
+        news_id AS newsId,
+        token_id AS tokenId,
+        summary_short AS summaryShort,
+        summary_text AS summaryText,
+        news_type AS newsType,
+        avg_change_rate AS avgChangeRate,
+        adr_value AS adrValue,
+        vol_growth_rate AS volGrowthRate,
+        highlight_tokens AS highlightTokens,
+        created_at AS createdAt
+        FROM marketnews
+        WHERE news_type = #{newsType}
+        ORDER BY created_at DESC
+        LIMIT 10
+    </select>
+
+    <select id="selectNewsById" parameterType="long" resultType="MarketNewsDTO">
+        SELECT
+        news_id AS newsId,
+        token_id AS tokenId,
+        summary_short AS summaryShort,
+        summary_text AS summaryText,
+        news_type AS newsType,
+        avg_change_rate AS avgChangeRate,
+        adr_value AS adrValue,
+        vol_growth_rate AS volGrowthRate,
+        highlight_tokens AS highlightTokens,
+        created_at AS createdAt
+        FROM marketnews
+        WHERE news_id = #{newsId}
+    </select>
+
+    <!--    <select id="selectNewsByTokenId" parameterType="long" resultType="MarketNewsDTO">-->
+    <!--        SELECT-->
+    <!--        news_id AS newsId,-->
+    <!--        token_id AS tokenId,-->
+    <!--        summary_short AS summaryShort,-->
+    <!--        summary_text AS summaryText,-->
+    <!--        news_type AS newsType,-->
+    <!--        avg_change_rate AS avgChangeRate,-->
+    <!--        adr_value AS adrValue,-->
+    <!--        vol_growth_rate AS volGrowthRate,-->
+    <!--        highlight_tokens AS highlightTokens,-->
+    <!--        created_at AS createdAt-->
+    <!--        FROM marketnews-->
+    <!--        WHERE token_id = #{tokenId}-->
+    <!--        ORDER BY created_at DESC-->
+    <!--    </select>-->
+
+</mapper>


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- LlmService를 중심으로 프롬프트 구성, OpenAI 호출 방식, 응답 파싱 흐름을 확인
- MarketNewsService에서 시장 데이터 수집, 지표 계산, LLM 요청 데이터 조립, 뉴스 저장까지의 전체 생성 로직
- MarketNewsRepository와 MyBatis 매퍼를 확인해 마리팜db의 marketnews 테이블에 뉴스 저장 및 조회 구조를 검토


<img width="1518" height="131" alt="image" src="https://github.com/user-attachments/assets/c3f72fff-13f1-4a55-8770-eddbb6a8127e" />
