### PR TITLE
[FEAT] 서비스 이용약관 페이지 추가

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,7 @@ import {
   ProjectRegister,
   RevenueRegister,
 } from '@/pages/admin';
+import Policy from '@/pages/Policy/Policy';
 import FindPassword from './pages/Auth/components/FindPassword';
 import ResetPassword from './pages/Auth/components/ResetPassword';
 
@@ -105,6 +106,7 @@ function App() {
           <Route path="/admin/cultivation" element={<CultivationRegister />} />
           <Route path="/admin/expense" element={<ExpenseRegister />} />
           <Route path="/admin/revenue" element={<RevenueRegister />} />
+          <Route path="/policy" element={<Policy />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </main>

--- a/frontend/src/pages/Auth/Login.tsx
+++ b/frontend/src/pages/Auth/Login.tsx
@@ -39,7 +39,9 @@ export default function Login() {
         localStorage.setItem("loginStartTime", now);
         localStorage.setItem("lastActivityTime", now);
 
-            navigate("/");
+            navigate("/", {
+                state: { toastMessage: "로그인 성공!" },
+            });
         } catch (err) {
             console.error("로그인 실패:", err);
             setError("이메일 또는 비밀번호를 확인하세요.");

--- a/frontend/src/pages/Auth/Signup.tsx
+++ b/frontend/src/pages/Auth/Signup.tsx
@@ -525,7 +525,7 @@ export default function Signup() {
   }
 
   return (
-    <main className="flex-1 flex flex-col items-center py-10 bg-gray-50 min-h-[calc(75vh-var(--spacing-header-height))]">
+    <main className="flex min-h-[calc(100dvh-var(--spacing-header-height))] flex-col items-center justify-center px-6 py-10">
       <div className="w-full max-w-[520px]">
         <SignupProgress
           totalSteps={totalSteps}

--- a/frontend/src/pages/Auth/components/FindPasswordForm.tsx
+++ b/frontend/src/pages/Auth/components/FindPasswordForm.tsx
@@ -35,7 +35,7 @@ export default function FindPasswordForm({
   onSubmit,
 }: FindPasswordFormProps) {
   return (
-    <div className="flex min-h-[calc(100dvh-var(--spacing-header-height))] flex-col items-center justify-center bg-gray-50 px-6 py-10">
+    <div className="flex min-h-[calc(100dvh-var(--spacing-header-height))] flex-col items-center justify-center px-6 py-10">
       <AuthCard
         title="비밀번호 찾기"
         description="이메일 인증 후 새로운 비밀번호를 설정합니다"

--- a/frontend/src/pages/Auth/components/ResetPasswordForm.tsx
+++ b/frontend/src/pages/Auth/components/ResetPasswordForm.tsx
@@ -30,7 +30,7 @@ export default function ResetPasswordForm({
   onSubmit,
 }: ResetPasswordFormProps) {
   return (
-    <div className="flex min-h-[calc(100dvh-var(--spacing-header-height))] flex-col items-center justify-center bg-gray-50 px-6 py-10">
+    <div className="flex min-h-[calc(100dvh-var(--spacing-header-height))] flex-col items-center justify-center px-6 py-10">
       <AuthCard
         title="비밀번호 재설정"
         description="이메일 인증 후 새 비밀번호를 설정하세요."

--- a/frontend/src/pages/Auth/components/SignupSelect.tsx
+++ b/frontend/src/pages/Auth/components/SignupSelect.tsx
@@ -13,7 +13,7 @@ export default function SignupTypeSelect({
   onGoLogin,
 }: SignupTypeSelectProps) {
   return (
-    <main className="flex-1 flex flex-col min-h-[calc(75vh-var(--spacing-header-height))] items-center py-10 pt-20 bg-gray-50">
+    <main className="flex min-h-[calc(100dvh-var(--spacing-header-height))] flex-col items-center justify-center px-6 py-10">
       <AuthCard
         title="회원가입"
         description="가입하실 회원 유형을 선택해주세요"

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -4,10 +4,29 @@ import CarbonSection from "./components/CarbonSection";
 import ProjectSection from "./components/ProjectSection";
 import StatusSection from "./components/StatusSection";
 import HeroSection from "./components/HeroSection";
+import { useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import Toast from "@/components/common/Toast";
 
 function Home() {
+  const location = useLocation();
+  const [toastMessage, setToastMessage] = useState("");
+
+  useEffect(() => {
+    if (location.state?.toastMessage) {
+      setToastMessage(location.state.toastMessage);
+    }
+  }, [location.state]);
+  
   return (
     <div className="flex flex-col">
+      {toastMessage && (
+        <Toast
+          message={toastMessage}
+          onClose={() => setToastMessage("")}
+        />
+      )}
+
       <HeroSection />
       <StatusSection />
       <ProjectSection />

--- a/frontend/src/pages/Policy/Policy.tsx
+++ b/frontend/src/pages/Policy/Policy.tsx
@@ -1,0 +1,430 @@
+import { useState } from "react";
+
+type PolicyTab = "marifarm" | "sto" | "trade" | "dividend" | "carbon";
+
+export default function Policy() {
+  const [activeTab, setActiveTab] = useState<PolicyTab>("marifarm");
+
+  const tabStyle = (tab: PolicyTab) =>
+    `w-full text-left px-4 py-3 rounded-xl text-sm transition-colors cursor-pointer ${
+      activeTab === tab
+        ? "bg-green-50 text-green-700 font-semibold"
+        : "text-gray-700 hover:bg-gray-50"
+    }`;
+
+  const sectionTitleClass = "text-2xl font-bold text-gray-900 mb-6";
+  const articleTitleClass = "text-lg font-semibold text-gray-900 mt-6 mb-2";
+  const bodyClass = "text-sm leading-7 text-gray-700";
+  const ulClass = "list-disc pl-6 space-y-1";
+  const pClass = "text-sm leading-7 text-gray-700";
+
+  return (
+    <main className="max-w-[1200px] mx-auto px-4 py-10 flex flex-col gap-6 md:flex-row">
+      <aside className="w-full md:w-[280px] md:shrink-0 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm h-fit">
+        <h2 className="text-xl font-bold text-gray-900 mb-4">이용약관</h2>
+
+        <ul className="flex flex-col gap-2">
+          <li>
+            <button
+              type="button"
+              className={tabStyle("marifarm")}
+              onClick={() => setActiveTab("marifarm")}
+            >
+              마리팜 이용약관
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className={tabStyle("sto")}
+              onClick={() => setActiveTab("sto")}
+            >
+              STO 청약 서비스 이용약관
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className={tabStyle("trade")}
+              onClick={() => setActiveTab("trade")}
+            >
+              토큰 증권 거래 이용약관
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className={tabStyle("dividend")}
+              onClick={() => setActiveTab("dividend")}
+            >
+              수익 분배 및 배당 이용약관
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className={tabStyle("carbon")}
+              onClick={() => setActiveTab("carbon")}
+            >
+              탄소배출권 거래 운영 규정
+            </button>
+          </li>
+        </ul>
+      </aside>
+
+      <article className="flex-1 rounded-2xl border border-gray-200 bg-white p-6 md:p-8 shadow-sm">
+        {activeTab === "marifarm" && (
+          <section>
+            <h3 className={sectionTitleClass}>마리팜 이용약관</h3>
+            <div className="space-y-2">
+              <h4 className={articleTitleClass}>제1조 (목적)</h4>
+              <p className={pClass}>
+                본 약관은 회사가 운영하는 '마리팜' 플랫폼의 회원 가입, 계정 관리 및 서비스 이용에 관한 기본적인 사항을 규정함을 목적으로 합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제2조 (용어의 정의)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>
+                  <b>서비스</b>: 단말기에 상관없이 회원이 이용할 수 있는 마리팜의 STO 청약, 거래, 수익 분배 서비스를 의미합니다.
+                </li>
+                <li>
+                  <b>디지털 자산(ST)</b>: 스마트팜 기초자산에서 발생하는 수익에 대한 권리를 블록체인 기술 기반의 디지털 원장에 전자적으로 기록한 수익권 토큰을 말합니다.
+                </li>
+                <li>
+                  <b>기초자산</b>: ST의 가치를 뒷받침하는 실제 스마트팜 시설, 장비 및 재배 중인 작물을 말합니다.
+                </li>
+                <li>
+                  <b>예치금(KRW)</b>: 서비스 내에서 ST의 매수 및 수익금 수령을 위해 사용하는 현금성 지급 수단을 말합니다.
+                </li>
+                <li>
+                  <b>지갑(Wallet)</b>: 회원의 ST 보유 현황 및 거래 내역을 관리하는 디지털 보관함을 의미합니다.
+                </li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제3조 (회원 가입 및 종류)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>서비스는 이메일 계정을 아이디로 사용하며, '1인 1계정' 원칙을 적용합니다.</li>
+                <li>회원은 일반 회원(개인)과 법인 회원(기업)으로 구분되며, 각 성격에 맞는 증빙 서류를 제출해야 합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제4조 (본인 인증 절차)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>일반 회원은 본인 명의 휴대폰 인증을 거쳐야 합니다.</li>
+                <li>법인 회원은 대표자 또는 담당자 개인 명의 인증, 혹은 실사용자로 등록된 법인 명의 휴대폰을 통해 인증해야 합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제5조 (계정 보안 및 책임)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원은 비밀번호 및 2차 인증 정보를 스스로 관리해야 하며, 관리 소홀로 인한 손해는 회원이 부담합니다.</li>
+                <li>계정 도용 의심 시 즉시 회사에 통보해야 하며, 회사는 즉시 계정 동결 등의 조치를 취합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제6조 (약관의 게시와 개정)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회사는 본 약관의 내용을 회원이 쉽게 알 수 있도록 서비스 내 화면에 게시합니다.</li>
+                <li>회사는 관련 법령을 위배하지 않는 범위에서 본 약관을 개정할 수 있으며, 개정 시 적용일자 30일 전부터 공지합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제7조 (약관의 해석)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회사는 서비스 이용과 관련하여 별도의 이용자 가이드를 둘 수 있으며, 본 약관과 상충할 경우 약관이 우선합니다.</li>
+                <li>본 약관에서 정하지 아니한 사항은 관련 법령 또는 상관례에 따릅니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제8조 (이용계약의 체결)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>이용계약은 가입 신청자가 약관에 동의하고 회사가 정한 고객확인절차(KYC)를 완료함으로써 체결됩니다.</li>
+                <li>회사는 타인 명의 사용, 허위 정보 기재, 위험 국가 거주자 등의 사유가 있는 경우 승낙을 거절하거나 사후에 계약을 해지할 수 있습니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제9조 (회원 정보의 변경)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원은 개인정보관리화면을 통해 언제든지 본인의 개인정보를 열람하고 수정할 수 있습니다.</li>
+                <li>회원은 가입 시 기재한 사항이 변경되었을 경우 즉시 수정하거나 고객센터를 통해 알려야 하며, 이를 게을리하여 발생한 손해는 회원이 부담합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제10조 (회원 정보의 관리)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원은 자신의 계정 및 비밀번호가 도용되지 않도록 안전하게 관리할 책임이 있습니다.</li>
+                <li>계정 도용이 의심되는 경우 회원은 즉시 회사에 통지해야 하며, 회사는 즉시 계정 이용 중단 등의 조치를 취할 수 있습니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제11조 (개인정보의 보호)</h4>
+              <p className={pClass}>
+                회사는 개인정보 보호법 등 관련 법령이 정하는 바에 따라 회원의 개인정보를 보호하기 위해 노력하며, 별도의 개인정보 처리방침을 준수합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제12조 (회사의 의무)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회사는 관련 법령과 본 약관을 준수하며 계속적이고 안정적으로 서비스를 제공하기 위해 노력합니다.</li>
+                <li>회사는 회원이 안전하게 서비스를 이용할 수 있도록 보안 시스템을 구축하고 유지합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제13조 (회원의 의무 및 금지행위)</h4>
+              <p className={pClass}>회원은 아래의 행위를 하여서는 안 됩니다.</p>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>시세 조종, 자가 매매 등 건전한 거래 질서를 교란하는 행위</li>
+                <li>자동화된 수단(에이전트, 스크립트 등)을 이용한 비정상적 서비스 접속</li>
+                <li>2개 이상의 계정을 사용한 입출금 한도 회피 행위</li>
+                <li>기타 관련 법령에 위반되는 불법적인 행위</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제14조 (예치금의 보호)</h4>
+              <p className={pClass}>
+                회사는 회원의 예치금을 회사의 고유재산과 분리하여 은행 등 외부 공신력 있는 기관에 예치 또는 신탁하여 관리함으로써 안전성을 확보합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제15조 (원천징수의무)</h4>
+              <p className={pClass}>
+                회사는 세법에서 정한 원천징수의무자로서 비거주자 또는 외국법인 등 납세의무자의 디지털 자산 소득에 대하여 원천징수하고 신고 및 납부할 수 있습니다.
+              </p>
+            </div>
+          </section>
+        )}
+
+        {activeTab === "sto" && (
+          <section>
+            <h3 className={sectionTitleClass}>STO 청약 서비스 이용약관</h3>
+            <div className="space-y-2">
+              <h4 className={articleTitleClass}>제1조 (목적)</h4>
+              <p className={pClass}>
+                본 약관은 회사가 발행 지원하는 스마트팜 ST의 신규 발행 및 청약 서비스 이용에 관한 청약 신청, 배정, 환불 등의 제반 사항을 규정함을 목적으로 합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제2조 (청약 신청)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원은 공고된 프로젝트의 모집 기간 내에 예치금을 담보로 청약을 신청할 수 있습니다.</li>
+                <li>청약 신청 시 지갑 내 예치금 잔액이 신청 금액 이상이어야 합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제3조 (투자자 등급별 청약 한도)</h4>
+              <p className={pClass}>
+                회사는 관련 법령에 따라 일반 투자자, 소득적격 투자자, 전문 투자자별로 연간 및 프로젝트당 투자 한도를 제한합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제4조 (배정 원칙 및 잔액 환불)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>모집 금액 초과 청약 시 신청 금액에 비례하여 안분배정(비례배정)함을 원칙으로 합니다.</li>
+                <li>미배정된 청약 증거금은 배정 확정일로부터 2영업일 이내에 회원의 예치금 계좌로 자동 환불됩니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제5조 (청약의 성립 및 취소)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>청약 마감일까지 목표 금액의 80% 이상 모집 시 청약이 성립됩니다.</li>
+                <li>청약 기간 중에는 자유롭게 취소가 가능하나, 마감 이후에는 프로젝트 운영 안정성을 위해 취소가 불가합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제6조 (발행 수수료)</h4>
+              <p className={pClass}>
+                청약 성공 시 발행 가액의 일정 비율이 발행 수수료로 부과될 수 있으며, 이는 청약 상세 공고에 명시합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제7조 (모집 실패 시 조치)</h4>
+              <p className={pClass}>
+                목표 금액 미달로 청약이 불성립될 경우, 회사는 모집된 금액 전액을 별도 수수료 없이 회원의 예치금 계좌로 즉시 반환합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제8조 (결과 공시)</h4>
+              <p className={pClass}>
+                회사는 청약 종료 후 배정 결과 및 모집 성공 여부를 서비스 내 게시판 또는 개별 통지를 통해 지체 없이 공시합니다.
+              </p>
+            </div>
+          </section>
+        )}
+
+        {activeTab === "trade" && (
+          <section>
+            <h3 className={sectionTitleClass}>토큰 증권 거래 이용약관</h3>
+            <div className="space-y-2">
+              <h4 className={articleTitleClass}>제1조 (목적)</h4>
+              <p className={pClass}>
+                본 약관은 회원 간의 토큰 증권(ST) 매매 거래가 이루어지는 유통 시장(마켓) 서비스의 운영 원칙과 이용 절차를 규정함을 목적으로 합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제2조 (거래 체결 원칙)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회사는 매도인과 매수인 간의 중개자 역할을 수행하며, 가격 우선 및 시간 우선 원칙에 따라 매매를 체결합니다.</li>
+                <li>체결된 거래는 즉시 분산원장에 기록되며, 기록 후에는 취소하거나 번복할 수 없습니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제3조 (거래의 중단 및 제한)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>시스템 점검, 보안 사고, 혹은 기초자산의 중대한 변동 시 회사는 거래를 일시 정지할 수 있습니다.</li>
+                <li>부정 거래 정황이 포착될 경우 회사는 특정 계정의 거래를 제한할 수 있습니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제4조 (거래 수수료)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원은 거래 체결 시 회사가 정한 요율에 따라 거래 수수료를 지불해야 합니다.</li>
+                <li>수수료율은 서비스 내 안내 페이지를 통해 상시 공시합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제5조 (주문 및 체결)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원은 매수/매도 시 수량과 가격을 지정하여 주문을 제출합니다.</li>
+                <li>예치금 또는 ST 보유 수량이 부족한 경우 주문 제출이 제한됩니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제6조 (미체결 주문)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>체결되지 않은 주문은 회원이 직접 취소할 수 있습니다.</li>
+                <li>특정 기간(예: 30일) 동안 체결되지 않은 주문은 시스템에 의해 자동 취소될 수 있습니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제7조 (이상 거래 모니터링)</h4>
+              <p className={pClass}>
+                회사는 불공정 거래 방지를 위해 상시 모니터링을 실시하며, 혐의가 있는 경우 금융당국에 보고하거나 거래를 제한할 권한을 가집니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제8조 (시장 안정화 조치)</h4>
+              <p className={pClass}>
+                회사는 급격한 시세 변동이나 시스템 오류 발생 시 거래를 일시 정지하거나 특정 가격 범위 내에서만 주문을 허용할 수 있습니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제9조 (불공정 거래 금지)</h4>
+              <p className={pClass}>
+                자전거래, 허수주문, 시세조종 등 시장 질서를 교란하는 모든 행위를 엄격히 금지하며 적발 시 즉시 이용이 제한됩니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제10조 (거래 확인서)</h4>
+              <p className={pClass}>
+                회원은 자신의 매매 내역에 대해 전자적 형태의 거래 확인서를 언제든지 열람하거나 발급받을 수 있습니다.
+              </p>
+            </div>
+          </section>
+        )}
+
+        {activeTab === "dividend" && (
+          <section>
+            <h3 className={sectionTitleClass}>수익 분배 및 배당 이용약관</h3>
+            <div className="space-y-2">
+              <h4 className={articleTitleClass}>제1조 (목적)</h4>
+              <p className={pClass}>
+                본 약관은 스마트팜 자산의 실제 운영 방식과 그로부터 발생하는 운영 수익(현금 배당) 및 탄소 수익(포인트/우선권)의 산정 및 분배에 관한 사항을 규정함을 목적으로 합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제2조 (수익의 정의 및 산정 방식)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>
+                  <b>운영 수익</b>: 스마트팜 매출에서 직접 비용과 운영 수수료를 제외한 '순수익'을 의미합니다.
+                </li>
+                <li>
+                  <b>탄소 수익</b>: 스마트팜 운영을 통해 획득한 탄소배출권의 판매 수익을 의미하며, 이는 현금 배당과 별도로 관리됩니다.
+                </li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제3조 (순수익의 산정 및 공제 항목)</h4>
+              <p className={pClass}>
+                수익 분배의 기준이 되는 '순수익'은 총 매출액(작물 판매 대금 등)에서 다음 항목을 차감하여 산정합니다.
+              </p>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>
+                  <b>직접 운영비</b>: 종자, 비료, 에너지 비용(전기/수도), 시설 점검 및 소모품비.
+                </li>
+                <li>
+                  <b>위탁 관리비</b>: 인건비 및 위탁 운영 수수료.
+                </li>
+                <li>
+                  <b>보험료 및 세금</b>: 농작물 재해보험료, 기타 서비스 유지에 필요한 법정 수수료 및 제세공과금.
+                </li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제4조 (현금 배당 및 정산)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회사는 확정된 순수익의 70%를 배당 가능 재원으로 확정하고 지배적 소유 비율에 따라 배분합니다.</li>
+                <li>배당금은 원천징수 후 잔액을 회원의 예치금 지갑으로 입금합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제5조 (정산 주기)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>수익 정산은 작물의 수확 및 판매가 완료된 후 대금 회수 시점을 기준으로 시행합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제6조 (개인 회원: 탄소 포인트 보상)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>개인 회원에게는 배출권 수익을 기반으로 산정된 '탄소 포인트'가 지급될 수 있으며, 이는 플랫폼 내 포인트 샵에서 사용 가능합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제7조 (법인 회원: 배출권 우선권 혜택)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>법인 회원에게는 투자 지분에 비례하여 프로젝트에서 발생한 배출권을 시장 가격보다 유리하게 우선 매수할 수 있는 '우선권'이 부여됩니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제8조 (미수령 배당금의 처리)</h4>
+              <p className={pClass}>
+                회원이 계정 상태 이상 등으로 배당금을 수령하지 못한 경우, 회사는 해당 금액을 별도 계정에서 안전하게 보관하며 회원의 요청 시 지급합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제9조 (자산 운영 및 정보 공시)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회사는 전문적인 농장 관리를 위해 위탁 운영을 실시할 수 있으며, 분기별 운영 보고서를 공시합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제10조 (불가항력 면책 및 위험 고지)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>천재지변, 예기치 못한 병충해 등으로 인한 수확량 감소 시 회사는 운영에 최선을 다했음에도 발생한 손실에 대해 책임을 지지 않습니다.</li>
+              </ul>
+            </div>
+          </section>
+        )}
+
+        {activeTab === "carbon" && (
+          <section>
+            <h3 className={sectionTitleClass}>탄소배출권 거래 운영 규정</h3>
+            <div className="space-y-2">
+              <h4 className={articleTitleClass}>제1조 (목적)</h4>
+              <p className={pClass}>
+                본 규정은 마이리틀스마트팜 탄소 마켓에서 거래되는 탄소배출권 및 자발적 감축 크레딧의 매매, 정산, 인증서 발급 및 상쇄 절차를 규정함을 목적으로 합니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제2조 (거래 대상의 종류)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>
+                  <b>KOC/KRU</b>: 환경부 승인을 받은 온실가스 배출권 거래제 상의 외부사업 감축량.
+                </li>
+                <li>
+                  <b>VER (Voluntary Emission Reduction)</b>: 스마트팜 프로젝트를 통해 발생한 자발적 탄소 크레딧.
+                </li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제3조 (거래 단위 및 호가)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>
+                  <b>매매 단위</b>: 탄소배출권의 거래 단위는 1 tCO2-eq(이산화탄소 상당량 1톤)로 합니다.
+                </li>
+                <li>
+                  <b>호가 단위</b>: 대한민국 원화(KRW) 기준 최소 호가 단위는 10원으로 합니다.
+                </li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제4조 (매매 체결 및 소유권 이전)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>본 마켓의 매매는 상대매매 또는 경쟁매매 방식을 따르며, 체결 즉시 디지털 원장에 기록되어 소유권이 이전됩니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제5조 (상쇄 및 폐기 절차)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>회원이 탄소 중립을 목적으로 상쇄 신청 시, 해당 크레딧은 즉시 일련번호가 효력 정지(폐기)되며 회사는 '탄소 상쇄 증명서'를 발행합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제6조 (수수료 및 정산)</h4>
+              <ul className={`${ulClass} ${bodyClass}`}>
+                <li>탄소 마켓 거래 수수료는 체결 금액의 0.2%(VAT 별도)를 원칙으로 합니다.</li>
+              </ul>
+
+              <h4 className={articleTitleClass}>제7조 (모니터링 및 검증)</h4>
+              <p className={pClass}>
+                회사는 IoT 센서 데이터를 바탕으로 스마트팜 내 탄소 감축량을 실시간 모니터링하며, 공인된 제3자 검증 기관을 통해 감축량을 검증받습니다.
+              </p>
+
+              <h4 className={articleTitleClass}>제8조 (거래의 제한)</h4>
+              <p className={pClass}>
+                회사는 시장 안정화를 위해 가격 급등락 시 서킷브레이커를 발동할 수 있으며, 부정 거래 가담 시 해당 회원을 영구 제명할 수 있습니다.
+              </p>
+            </div>
+          </section>
+        )}
+      </article>
+    </main>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- footer에 있는 서비스 이용약관 페이지를 만들어 탄소 결제시 이용약관 및 거래에 대한 규정을 볼 수 있게 추가해놨습니다.
- 변경된 로그인 디자인에 맞춰 회원가입, 비밀번호 찾기 페이지에도 적용시켰습니다.
- 로그인 성공 후 메인페이지로 전환될 때 toast 에 로그인 성공 메시지를 담아 띄웠습니다.

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 회원가입 디자인 입니다. | <img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/05f894c6-958b-4fc0-bdf4-1b589b52b4a5" /> |
| 서비스 이용약관 페이지 입니다. | <img width="1919" height="1031" alt="image" src="https://github.com/user-attachments/assets/3ba99f9f-7f08-4bbe-b406-b9bbacf75b01" /> |
| 토스트 메시지 입니다. |<img width="1918" height="1027" alt="image" src="https://github.com/user-attachments/assets/d804c49e-85a8-4487-81fa-d89707279b28" />|

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
