### PR TITLE
[CHORE] 청약 모달 이미지 보이도록 수정

### DIFF
--- a/frontend/src/pages/project/ProjectDetail.tsx
+++ b/frontend/src/pages/project/ProjectDetail.tsx
@@ -157,6 +157,7 @@ export default function ProjectDetail() {
             price: Math.floor(
               projectData.targetAmount / projectData.totalSupply,
             ),
+            thumbnailUrl: projectData.thumbnailUrl,
             userLimit: 500000000,
             minAmountPerInvestor: projectData.minAmountPerInvestor,
           }}

--- a/frontend/src/pages/project/ProjectDetail.tsx
+++ b/frontend/src/pages/project/ProjectDetail.tsx
@@ -157,7 +157,7 @@ export default function ProjectDetail() {
             price: Math.floor(
               projectData.targetAmount / projectData.totalSupply,
             ),
-            thumbnailUrl: projectData.thumbnailUrl,
+            thumbnailUrl: projectData.images?.[0] ?? '',
             userLimit: 500000000,
             minAmountPerInvestor: projectData.minAmountPerInvestor,
           }}

--- a/frontend/src/pages/project/components/SubscriptionModal.tsx
+++ b/frontend/src/pages/project/components/SubscriptionModal.tsx
@@ -18,7 +18,7 @@ interface SubscriptionModalProps {
     tokenId: number;
     title: string;
     price: number;
-    thumbnail?: string;
+    thumbnailUrl?: string;
     userLimit: number;
     minAmountPerInvestor: number;
   };
@@ -129,7 +129,7 @@ export default function SubscriptionModal({
         </div>
 
         <SubscriptionSummary
-          thumbnail={projectData.thumbnail}
+          thumbnail={projectData.thumbnailUrl}
           title={projectData.title}
           labelText={`1 토큰 당 ${projectData.price.toLocaleString()}원`}
         />

--- a/frontend/src/pages/project/components/SubscriptionSummary.tsx
+++ b/frontend/src/pages/project/components/SubscriptionSummary.tsx
@@ -1,3 +1,5 @@
+import Icon from '@/components/icon';
+
 interface SummaryProps {
   thumbnail?: string;
   title: string;
@@ -12,11 +14,17 @@ export const SubscriptionSummary = ({
 }: SummaryProps) => (
   <div className="flex items-center gap-3.5 bg-gray-50 rounded-[12px] p-3.5 mb-5">
     {/* 썸네일 */}
-    <img
-      src={thumbnail || '/default-thumb.png'}
-      className="w-16 h-16 rounded-lg object-cover"
-      alt="thumb"
-    />
+    {thumbnail ? (
+      <img
+        src={thumbnail}
+        className="w-16 h-16 rounded-lg object-cover"
+        alt="thumb"
+      />
+    ) : (
+      <div className="w-16 h-16 rounded-lg bg-green-50 flex items-center justify-center">
+        <Icon name="leaf" color="var(--color-green-600)" size={28} />
+      </div>
+    )}
 
     <div className="flex flex-col gap-1">
       {/* 제목 */}

--- a/frontend/src/types/projectType.ts
+++ b/frontend/src/types/projectType.ts
@@ -33,6 +33,7 @@ export interface ProjectData {
   method: string;
   temperatureInside: number[];
   humidityInside: number[];
+  thumbnailUrl?: string;
 
   farm: {
     addressSido: string;

--- a/frontend/src/types/projectType.ts
+++ b/frontend/src/types/projectType.ts
@@ -33,7 +33,6 @@ export interface ProjectData {
   method: string;
   temperatureInside: number[];
   humidityInside: number[];
-  thumbnailUrl?: string;
 
   farm: {
     addressSido: string;


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 청약 모달에 이미지 나오도록 수정하였습니다.
- 만약 이미지가 없는 경우 마리팜 로고가 나오도록 수정하였습니다.

## 📝 변경 사항 (Key Changes)
- [ ] 
- [ ] 

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 사진 없는 경우 | <img width="528" height="651" alt="image" src="https://github.com/user-attachments/assets/4bfc29ee-d262-449e-9f70-a776dabdab22" /> |
| 사진 있는 경우 | <img width="482" height="635" alt="image" src="https://github.com/user-attachments/assets/171fadb7-f3cb-4329-97f0-8365b52be68d" /> |


## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
