### PR TITLE
[FEAT] 사용자 투자 한도 설정

### DIFF
--- a/backend/src/main/java/com/animalfarm/backend/batch/writer/ProjectClosingWriter.java
+++ b/backend/src/main/java/com/animalfarm/backend/batch/writer/ProjectClosingWriter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.animalfarm.backend.domain.accounting.dto.RefundTokenLedgerDTO;
 import com.animalfarm.backend.domain.refund.RefundRepository;
+import com.animalfarm.backend.domain.subscription.SubscriptionRepository;
 import com.animalfarm.backend.domain.token.TokenRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class ProjectClosingWriter implements ItemWriter<RefundTokenLedgerDTO> {
 	private final RefundRepository refundRepository;
 	private final TokenRepository tokenRepository;
+	private final SubscriptionRepository subscriptionRepository;
 
 	@Override
 	// 2. 파라미터 타입을 List<? extends T>에서 Chunk<? extends T>로 변경
@@ -22,6 +24,10 @@ public class ProjectClosingWriter implements ItemWriter<RefundTokenLedgerDTO> {
 		for (RefundTokenLedgerDTO item : items) {
 			// 환불 정보 저장
 			refundRepository.insertRefund(item.getRefundDTO());
+			subscriptionRepository.restoreLimit(
+				item.getRefundDTO().getUserId(),
+				item.getRefundDTO().getAmount()
+			);
 
 			// 토큰 원장 저장
 			tokenRepository.insertTokenLedger(item.getTokenLedgerDTO());

--- a/backend/src/main/java/com/animalfarm/backend/domain/refund/RefundService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/refund/RefundService.java
@@ -5,14 +5,20 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import com.animalfarm.backend.domain.subscription.SubscriptionRepository;
+
 @Service
 public class RefundService {
 	@Autowired
 	RefundRepository refundRepository;
 
+	@Autowired
+	SubscriptionRepository subscriptionRepository;
+
 	public void insertRefunds(List<RefundDTO> refundList) {
 		for (RefundDTO refund : refundList) {
 			refundRepository.insertRefund(refund);
+			subscriptionRepository.restoreLimit(refund.getUserId(), refund.getAmount());
 		}
 	}
 }

--- a/backend/src/main/java/com/animalfarm/backend/domain/subscription/SubscriptionRepository.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/subscription/SubscriptionRepository.java
@@ -33,6 +33,10 @@ public interface SubscriptionRepository {
 
 	public abstract Long selectUclId(SubscriptionApplicationDTO subscriptionInsertDTO);
 
+	public abstract void useLimit(Long userId, BigDecimal amount);
+
+	public abstract void restoreLimit(Long userId, BigDecimal amount);
+
 	public abstract List<ProjectStartCheckDTO> selectExpiredSubscriptions();
 
 	public abstract AllocationStatsDTO selectAllocationStats(Long projectId, BigDecimal standardAmount);

--- a/backend/src/main/java/com/animalfarm/backend/domain/subscription/SubscriptionService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/subscription/SubscriptionService.java
@@ -121,6 +121,7 @@ public class SubscriptionService {
 			cancelApplication.setSubscriptionAmount(refundDTO.getAmount().multiply(new BigDecimal("-1")));
 			cancelApplication.setProjectId(refundDTO.getProjectId());
 			subscriptionRepository.updatePlusAmount(cancelApplication);
+			subscriptionRepository.restoreLimit(userId, refundDTO.getAmount());
 
 		} catch (RuntimeException e) {
 			// 유틸리티에서 던진 구체적인 에러 메시지("잔액 부족" 등)가 이곳으로 전달됨
@@ -259,6 +260,7 @@ public class SubscriptionService {
 
 		if ("PAID".equals(dto.getPaymentStatus())) {
 			subscriptionRepository.updatePlusAmount(dto);
+			subscriptionRepository.useLimit(dto.getUserId(), dto.getSubscriptionAmount());
 		}
 	}
 

--- a/backend/src/main/java/com/animalfarm/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/user/controller/UserController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.animalfarm.backend.domain.user.dto.UserDTO;
+import com.animalfarm.backend.domain.user.dto.UserInvestmentLimitDTO;
 import com.animalfarm.backend.domain.user.service.UserService;
 import com.animalfarm.backend.global.dto.ApiResponseDTO;
 import com.animalfarm.backend.global.exception.ErrorCode;
@@ -51,5 +52,23 @@ public class UserController {
 	public ResponseEntity<ApiResponseDTO<String>> getMyRole() {
 		String userRole = userService.getMyRole();
 		return ResponseEntity.ok(ApiResponseDTO.success(userRole));
+	}
+
+	@GetMapping("/myinvestmentlimit")
+	public ResponseEntity<ApiResponseDTO> getMyInvestmentLimit() {
+		// 1. SecurityUtil 등을 통해 현재 로그인한 유저 ID 획득
+		Long userId = SecurityUtil.getCurrentUserId();
+		if (userId == null) {
+			// 토큰이 없거나 유효하지 않은 경우 401 반환
+			return ResponseEntity
+				.status(HttpStatus.UNAUTHORIZED)
+				.body(ApiResponseDTO.fail(ErrorCode.NEED_LOGIN.getCode(), ErrorCode.NEED_LOGIN.getMessage()));
+		}
+
+		// 2. 서비스 호출
+		UserInvestmentLimitDTO limitInfo = userService.getUserInvestmentLimit(userId);
+
+		// 3. 기존에 약속된 응답 형식으로 반환
+		return ResponseEntity.ok(ApiResponseDTO.success(limitInfo));
 	}
 }

--- a/backend/src/main/java/com/animalfarm/backend/domain/user/dto/UserInvestmentLimitDTO.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/user/dto/UserInvestmentLimitDTO.java
@@ -1,0 +1,24 @@
+package com.animalfarm.backend.domain.user.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserInvestmentLimitDTO {
+	private Long userId;
+	private String investorType;
+	private BigDecimal annualLimit;     // 총 한도
+	private BigDecimal usedLimit;       // 사용액
+	private BigDecimal availableLimit; // 계산된 잔여 한도
+}

--- a/backend/src/main/java/com/animalfarm/backend/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import com.animalfarm.backend.domain.user.dto.UserDTO;
+import com.animalfarm.backend.domain.user.dto.UserInvestmentLimitDTO;
 
 @Mapper
 public interface UserRepository {
@@ -27,4 +28,6 @@ public interface UserRepository {
 	String selectUserNameById(Long userId);
 
 	String selectUserRoleById(Long userId);
+
+	UserInvestmentLimitDTO selectUserInvestmentLimit(Long userId);
 }

--- a/backend/src/main/java/com/animalfarm/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/animalfarm/backend/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.animalfarm.backend.domain.user.service;
 
+import java.math.BigDecimal;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -7,8 +9,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import com.animalfarm.backend.domain.user.dto.UserDTO;
+import com.animalfarm.backend.domain.user.dto.UserInvestmentLimitDTO;
 import com.animalfarm.backend.domain.user.repository.UserRepository;
 import com.animalfarm.backend.global.RedisUtil;
+import com.animalfarm.backend.global.exception.BusinessException;
+import com.animalfarm.backend.global.exception.ErrorCode;
 import com.animalfarm.backend.global.security.SecurityUtil;
 
 @Service
@@ -66,6 +71,21 @@ public class UserService {
 		}
 
 		return role;
+	}
+
+	public UserInvestmentLimitDTO getUserInvestmentLimit(Long userId) {
+		// 1. DB에서 한도 정보 조회 (Mapper 호출)
+		UserInvestmentLimitDTO limitDTO = userRepository.selectUserInvestmentLimit(userId);
+
+		if (limitDTO == null) {
+			throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		// 2. 가독성을 위해 현재 잔여 한도(Available)를 한 번 더 계산해서 세팅 (쿼리에서도 하지만 이중 확인)
+		BigDecimal available = limitDTO.getAnnualLimit().subtract(limitDTO.getUsedLimit());
+		limitDTO.setAvailableLimit(available.compareTo(BigDecimal.ZERO) < 0 ? BigDecimal.ZERO : available);
+
+		return limitDTO;
 	}
 
 }

--- a/backend/src/main/resources/mapper/SubscriptionMapper.xml
+++ b/backend/src/main/resources/mapper/SubscriptionMapper.xml
@@ -73,6 +73,27 @@
         #{subscriptionAmount} where project_id = #{projectId}
     </update>
 
+    <select id="">
+
+        
+    </select>
+
+    <update id="useLimit">
+        UPDATE users
+        SET used_limit_amount = used_limit_amount + #{amount},
+        updated_at = NOW()
+        WHERE user_id = #{userId}
+        AND (annual_limit_amount - used_limit_amount) >= #{amount}
+    </update>
+
+    <update id="restoreLimit">
+        UPDATE users
+        SET used_limit_amount = used_limit_amount - #{amount},
+        updated_at = NOW()
+        WHERE user_id = #{userId}
+        AND used_limit_amount >= #{amount}
+    </update>
+
     <select id="selectUclId" resultType="Long">
         select ucl.ucl_id from users
         u join user_certificate_links ucl on u.user_id = ucl.user_id

--- a/backend/src/main/resources/mapper/UserMapper.xml
+++ b/backend/src/main/resources/mapper/UserMapper.xml
@@ -6,10 +6,10 @@
 
     <select id="findByEmail" resultType="UserDTO">
         SELECT user_id,
-        email,
-        password,
-        user_name,
-        role
+               email,
+               password,
+               user_name,
+               role
         FROM users
         WHERE email = #{email}
     </select>
@@ -17,18 +17,28 @@
     <insert id="insertUser">
         INSERT INTO users (user_name, email, password, phone_number, role, brn)
         VALUES (#{userName}, #{email}, #{password}, #{phoneNumber}, #{role},
-        #{brn})
+                #{brn})
     </insert>
 
     <select id="existsByEmail" resultType="boolean">
         SELECT EXISTS (SELECT 1
-        FROM users
-        WHERE email = #{email})
+                       FROM users
+                       WHERE email = #{email})
     </select>
 
     <select id="selectAddress" resultType="string">
         SELECT address
         FROM users
+        WHERE user_id = #{userId}
+    </select>
+
+    <select id="selectUserInvestmentLimit" resultType="UserInvestmentLimitDTO">
+        SELECT user_id                                   AS userId,
+               investor_type                             AS investorType,
+               annual_limit_amount                       AS annualLimit,
+               used_limit_amount                         AS usedLimit,
+               (annual_limit_amount - used_limit_amount) AS availableLimit
+        FROM public.users
         WHERE user_id = #{userId}
     </select>
 

--- a/frontend/src/api/subscriptionApi.ts
+++ b/frontend/src/api/subscriptionApi.ts
@@ -1,4 +1,7 @@
-import type { SubscriptionApplicationDTO } from '@/types/subscriptionType';
+import type {
+  SubscriptionApplicationDTO,
+  UserInvestmentLimitDTO,
+} from '@/types/subscriptionType';
 import apiClient from './apiClient';
 
 export const subscriptionApi = {
@@ -12,5 +15,8 @@ export const subscriptionApi = {
     projectId: number,
   ): Promise<{ isApplied?: boolean; data?: { isApplied?: boolean } }> => {
     return apiClient.get(`/api/subscription/check/${projectId}`);
+  },
+  getUserInvestmentLimit: (): Promise<UserInvestmentLimitDTO> => {
+    return apiClient.get(`/api/user/myinvestmentlimit`);
   },
 };

--- a/frontend/src/pages/project/ProjectDetail.tsx
+++ b/frontend/src/pages/project/ProjectDetail.tsx
@@ -13,6 +13,7 @@ import AccountCheckFailModal from './components/AccountCheckFailModal';
 import { authApi } from '@/api/authApi';
 import { subscriptionApi } from '@/api/subscriptionApi';
 import Toast from '@/components/common/Toast';
+import type { UserInvestmentLimitDTO } from '@/types/subscriptionType';
 
 export default function ProjectDetail() {
   const { id } = useParams<{ id: string | undefined }>();
@@ -27,6 +28,8 @@ export default function ProjectDetail() {
   const navigate = useNavigate();
   const [isApplied, setIsApplied] = useState(false);
   const [toastMsg, setToastMsg] = useState<string | null>(null);
+  const [userInvestmentLimit, setUserInvestmentLimit] =
+    useState<UserInvestmentLimitDTO | null>(null);
   const handleCloseToast = useCallback(() => {
     setToastMsg(null);
   }, []);
@@ -95,6 +98,8 @@ export default function ProjectDetail() {
     try {
       const user = (await authApi.getUser()) as any;
       setCurrentUserId(user.userId);
+      const investmentLimit = await subscriptionApi.getUserInvestmentLimit();
+      setUserInvestmentLimit(investmentLimit);
       const checkacc = await projectApi.getCheckAccount(user.userId);
 
       if (checkacc === true) {
@@ -158,7 +163,7 @@ export default function ProjectDetail() {
               projectData.targetAmount / projectData.totalSupply,
             ),
             thumbnailUrl: projectData.images?.[0] ?? '',
-            userLimit: 500000000,
+            userLimit: userInvestmentLimit?.availableLimit ?? 0,
             minAmountPerInvestor: projectData.minAmountPerInvestor,
           }}
         />

--- a/frontend/src/types/subscriptionType.ts
+++ b/frontend/src/types/subscriptionType.ts
@@ -10,6 +10,18 @@ interface SubscriptionApplicationDTO {
   uclId?: number; // kh증권의 wallet_id
 }
 
+interface UserInvestmentLimitDTO {
+  userId: number;
+  investorType: string;
+  annualLimit: number;
+  usedLimit: number;
+  availableLimit: number;
+}
+
 type SubscriptionResultStatus = 'success' | 'api_fail' | 'empty_payload';
 
-export type { SubscriptionApplicationDTO, SubscriptionResultStatus };
+export type {
+  SubscriptionApplicationDTO,
+  SubscriptionResultStatus,
+  UserInvestmentLimitDTO,
+};


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 사용자 투자 한도 설정 컬럼 추가
- front 페이지에 설정

## 📝 변경 사항 (Key Changes)
- [ ] user 테이블에 컬럼 추가 annual_limit_amount, used_limit_amount

## 📸 스크린샷 (Screenshots / Demos)
| Feature | Screenshot |
| :--- | :--- |
| 청약 신청페이지 투자 한도 설정 | <img width="479" height="613" alt="image" src="https://github.com/user-attachments/assets/a44ab0b7-9be6-44be-9f9f-445c2cc842c3" /> |

## 🔗 연관된 이슈 (Related Issues)
- Close #

## 🧐 주요 리뷰 포인트 (Review Point)
- 

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
