### PR TITLE
[FIX] 메인페이지에서 로그인 성공 토스트 1회만 뜨게 수정

### DIFF
--- a/frontend/src/pages/home/index.tsx
+++ b/frontend/src/pages/home/index.tsx
@@ -3,20 +3,27 @@ import PartnerSection from "./components/PartnerSection";
 import TrustMetricsSection from "./components/TrustMetricsSection";
 import ProjectSection from "./components/ProjectSection";
 import HeroSection from "./components/HeroSection";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
 import Toast from "@/components/common/Toast";
 import PageShell from "@/components/layout/PageShell";
 
 function Home() {
   const location = useLocation();
+  const navigate = useNavigate();
   const [toastMessage, setToastMessage] = useState("");
 
   useEffect(() => {
-    if (location.state?.toastMessage) {
-      setToastMessage(location.state.toastMessage);
-    }
-  }, [location.state]);
+    const message = location.state?.toastMessage;
+    if (!message) return;
+
+    setToastMessage(message);
+
+    navigate(location.pathname, {
+      replace: true,
+      state: {},
+    });
+  }, [location.pathname, location.state, navigate]);
 
   return (
     <PageShell>
@@ -29,7 +36,6 @@ function Home() {
         )}
 
         <HeroSection />
-        {/* <StatusSection /> */}
         <TrustMetricsSection />
         <ProjectSection />
         <TokenSection />


### PR DESCRIPTION
## 📌 작업 내용 요약 (Summary)
- 로그인 후 메인페이지에서 새로고침을 하거나, 다른 탭에 갔다가 뒤로가기를 하게되면 로그인 성공 토스트가 계속 뜨던 현상을 수정하였습니다.

## ✅ 최종 PR전 체크 리스트 (Checklist)
- [x] 코딩 컨벤션(Checkstyle)을 준수하였는가?
- [x] 불필요한 주석이나 시스템 로그(console.log, print)를 제거하였는가?
- [x] 변경 사항에 대한 테스트를 완료하였는가?
- [x] 관련 문서를 업데이트하였는가?
